### PR TITLE
tsup demo

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
   "scripts": {
     "prepublishOnly": "npm run build",
     "build": "./scripts/build.sh --external:react --external:react-dom",
+    "build:tsup": "tsup src/index.ts --out-dir tsup --dts --format esm,cjs",
     "watch": "./scripts/watch.sh --external:react --external:react-dom",
+    "watch:tsup": "npm run build:tsup -- --watch",
     "test": "./scripts/test.sh",
     "test:watch": "./scripts/test.sh --watch",
     "test:snapshot": "npx jest --update-snapshot",
@@ -66,6 +68,7 @@
     "react-test-renderer": "^18.2.0",
     "rimraf": "^3.0.2",
     "snapshot-diff": "^0.8.1",
+    "tsup": "^6.7.0",
     "typescript": "^4.7.3"
   },
   "dependencies": {

--- a/tsup/index.cjs
+++ b/tsup/index.cjs
@@ -1,0 +1,2538 @@
+"use strict";
+var __create = Object.create;
+var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __getProtoOf = Object.getPrototypeOf;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __export = (target, all) => {
+  for (var name in all)
+    __defProp(target, name, { get: all[name], enumerable: true });
+};
+var __copyProps = (to, from, except, desc) => {
+  if (from && typeof from === "object" || typeof from === "function") {
+    for (let key of __getOwnPropNames(from))
+      if (!__hasOwnProp.call(to, key) && key !== except)
+        __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+  }
+  return to;
+};
+var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__getProtoOf(mod)) : {}, __copyProps(
+  // If the importer is in node compatibility mode or this is not an ESM
+  // file that has been converted to a CommonJS file using a Babel-
+  // compatible transform (i.e. "__esModule" has not been set), then set
+  // "default" to the CommonJS "module.exports" for node compatibility.
+  isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target,
+  mod
+));
+var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
+
+// src/index.ts
+var src_exports = {};
+__export(src_exports, {
+  Chain: () => Chain,
+  DetachedEthosConnectProvider: () => DetachedEthosConnectProvider_default,
+  EthosConnectProvider: () => EthosConnectProvider_default,
+  EthosConnectStatus: () => EthosConnectStatus,
+  IntentScope: () => import_sui6.IntentScope,
+  SignInButton: () => SignInButton_default,
+  TransactionBlock: () => import_sui6.TransactionBlock,
+  ethos: () => ethos,
+  verifyMessage: () => import_sui6.verifyMessage
+});
+module.exports = __toCommonJS(src_exports);
+var import_sui6 = require("@mysten/sui.js");
+
+// src/components/styled/SignInModal.tsx
+var import_react8 = require("react");
+
+// src/components/svg/Loader.tsx
+var Loader = ({ width = 100, color = "#333" }) => <svg
+  version="1.1"
+  id="L4"
+  xmlns="http://www.w3.org/2000/svg"
+  x="0px"
+  y="0px"
+  viewBox="0 0 54 20"
+  width={width}
+  height={width * (20 / 54)}
+  enableBackground="new 0 0 0 0"
+>
+  <circle fill={color} stroke="none" cx="6" cy="10" r="6"><animate
+    attributeName="opacity"
+    dur="1.5s"
+    values="0;1;0"
+    repeatCount="indefinite"
+    begin="0.1"
+  /></circle>
+  <circle fill={color} stroke="none" cx="26" cy="10" r="6"><animate
+    attributeName="opacity"
+    dur="1.5s"
+    values="0;1;0"
+    repeatCount="indefinite"
+    begin="0.5"
+  /></circle>
+  <circle fill={color} stroke="none" cx="46" cy="10" r="6"><animate
+    attributeName="opacity"
+    dur="1.5s"
+    values="0;1;0"
+    repeatCount="indefinite"
+    begin="1.0"
+  /></circle>
+</svg>;
+var Loader_default = Loader;
+
+// src/components/svg/WalletsIcon.tsx
+var WalletsIcon = ({ width = 32 }) => <img src={dataUri} width={width} height={width} />;
+var WalletsIcon_default = WalletsIcon;
+var dataUri = `data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAAeGVYSWZNTQAqAAAACAAFARIAAwAAAAEAAQAAARoABQAAAAEAAABKARsABQAAAAEAAABSASgAAwAAAAEAAgAAh2kABAAAAAEAAABaAAAAAAAAAEgAAAABAAAASAAAAAEAAqACAAQAAAABAAAAIKADAAQAAAABAAAAIAAAAAAQdIdCAAAACXBIWXMAAAsTAAALEwEAmpwYAAACZmlUWHRYTUw6Y29tLmFkb2JlLnhtcAAAAAAAPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyIgeDp4bXB0az0iWE1QIENvcmUgNS40LjAiPgogICA8cmRmOlJERiB4bWxuczpyZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiPgogICAgICA8cmRmOkRlc2NyaXB0aW9uIHJkZjphYm91dD0iIgogICAgICAgICAgICB4bWxuczp0aWZmPSJodHRwOi8vbnMuYWRvYmUuY29tL3RpZmYvMS4wLyIKICAgICAgICAgICAgeG1sbnM6ZXhpZj0iaHR0cDovL25zLmFkb2JlLmNvbS9leGlmLzEuMC8iPgogICAgICAgICA8dGlmZjpPcmllbnRhdGlvbj4xPC90aWZmOk9yaWVudGF0aW9uPgogICAgICAgICA8dGlmZjpSZXNvbHV0aW9uVW5pdD4yPC90aWZmOlJlc29sdXRpb25Vbml0PgogICAgICAgICA8ZXhpZjpDb2xvclNwYWNlPjE8L2V4aWY6Q29sb3JTcGFjZT4KICAgICAgICAgPGV4aWY6UGl4ZWxYRGltZW5zaW9uPjU2PC9leGlmOlBpeGVsWERpbWVuc2lvbj4KICAgICAgICAgPGV4aWY6UGl4ZWxZRGltZW5zaW9uPjU2PC9leGlmOlBpeGVsWURpbWVuc2lvbj4KICAgICAgPC9yZGY6RGVzY3JpcHRpb24+CiAgIDwvcmRmOlJERj4KPC94OnhtcG1ldGE+CiB3yYcAAAgwSURBVFgJrZddiJ1HGcefmXfe9z3n7G42yTYamy9sklZT0XilAeuFdwXxQrD4gVKwF6IXohdS8CYXJWJFwQvprXhTaOhVFakFjbGWioqItKYXprVda0OaNNnd8/F+jr//nN1k16RCwLM778w8M2f+//k/zzzzHme3+Zw+/Zuw+94TK7mvDucxHCws3h2ie19u9p68d3vy3kaFuYG3diH4We/9dJaF2SzLKG58xWfTyz4b/zvPJqsun6zW9eS1j2785ap76Gz333Buu+H0M2+OwrQ5Wzj/YBbNhWiWR2eAG+CxiJ6+WeijK5KNMWssy6YGCdWR4pwbWwgTbGNsam9QxtH5jSfqS6vfuv+hs/UW7g0C33l69WARu38GMx/Mxaw3l5uAXQypPScjQihgxSY51cE3mwQmAApY9Rx8Xs8JZNm6y/z6uCjHRw5+7GdXRMLr8bmnYtZZe6Hx0TdQalUYaVy02qKTjfpGUb/xLjbeotpdn1uMZey60vp+sFlKm/dxYJRddR77mC+0bfZyjKcTNhs221e89khjbhTZTc+DDbrAwmgWIx0sUMGgj6MbkQE3yOY8hTnWFy74HlB1OnOuTaXvW8BZ3eUOEtE5EQn73njxwleY+FMRcJ23M1BL6wQWjJDQ4n3sXX+TiAMSQoBDTNj84SAm43XYQqSkyZS+x9IB1lJvEaghUtOvWB8Sff6DRODrT720UFm717uMfTrWnxPp5VuBg8KSLnrUoEMcYmQO+8eDPMRHIokWoduVLkge1yXwmwTkkgqCBTVh7sPKhec/sxTqpeye2MKSBWPEsS5jB2wGcJFgYzBXu8MGCW1Wam0S2VJLdqbyBUK4G9CUC+SKDkAFacPUGn2IpjgDo3QL+cL7Q9O3xwnF6NmlAc6IdgtgFg/sLu3LJ1fcgeVCS+uTMObN2z53jM/GtV144YJV641IMFZBpKZdooACM9wXWl8fz5JgWfSA9z7AFAlQ5Esn73YXrkztr29xtFAjFThkYCM2tUs29jzvy0ZRX8d3tOjcoRNH7JUX1llPKtSclArwASoUwJTHyTHN0R4JCDnAgQDcm1c02PdffD1WtUAUIT7mSB9UEwvzXOBSPiixFXBWTijx2QAxKW5A0AyH5Jx+gd12gDeAb5EYupDNjobeNUcURYouoOZuYEGcZSujwj1y6qAd2lVK7y15t+rtPridzaYbnf3t3FWbrin4dCIatK6oZxAiX8TyMATa/TEpAAGCjJ0TTiLU2Vc/csxevrJmf740D3+FmcY0C0QiZu4WuUJp+0ZNWxlz12Kwwx9espfP1wQmIU1K0zH0viJTzmLXTvZLgZUEmBbPmCAAojLL4mN//LubNQJnaSnU4wg8zHFjVsAluAIg+bsg4AesgQtSe8isAbbdRWBmsEG3IAWso2RZzcGb4o7RXaHz7aLETwBKe0CwbgJZGZX2tQ/da0eWRtvltrcnjT3661f5SmYd5Fpi49EHD9reUUqsW+5wG+PWfnv+HZtWMCFdu3YXB4yk39aAJwUW2G49FKuOC2WzxN63Ue1vn/zALeBictcot6JouTMq7oTaFtnCJvgOoosLwT5+atnGxPaEUsXSte0ujuEuFFgiNS+XvnUtV3zDGaAA2rua01CTnmvbNxzsWHB75wv3v9f2LMRE5NP3LW8f2tFe2V0kAmOO9QTPVt3QmmY5EWm7xSKwW6U7PImL0pNZ8rfy/c3I37GoOg8cWEnlloHbGDa0lBJLRzzpr1s03yovVBbKjszEaJ/h+5TUcS2HheeWL2+z5J2Z1nRLEictSyrLKF35djdx0MQwaGrdXSRBT4Q6FXI+9wH1ncG8++w13VESgA2S7ri5kKHjZNV72jDqmoqoJxB1oyYCUoIY+N8ueHe4W0fGWU3A5rzgoIRncyDo7vTdoAnDtpr20Q+VfuZF11Jq/98UaMIYF5Sx4RqucUUdUJvXUw79LAyb9hqS7NXZl9vlfmKCE+Hj6vXL7uDyvlu3dAeWy7OpVdm6Zb7idJXWdgOrRQYNeO275kdVdWnU1kaJo7oylYWmjov1zD39p1/atcnaHcDtnHpx4x0789IfrM7XrQprbPe6zYprcZJfd1fyqb0Z2kth2NcX0fyUAkMxoIPCoZASce3tVffjZ35CctTdKGWQDWWSSvhQth7VFFyKGQq+9lw7ngSVWRMCL668H2WB3Sqd58R/4ZqsjDnvBE278I8wqGbnvPdf1GKQSGBC2GzLTyI1J5cIklXlrnRSAYXuZuyk+gYZEfEqEMnmZQaZJuSxznJXe37a+Py5EKb1s2WZ6fbV4dAjPclJMuEphkDTmKaIkKZIKeWt+Ty1PQTS24RebrFLFdRhXg8JyEglq7MM8GD8lLK1xp8XsHvyiW+us+ZIgHMeetObExGHBK7BTRLCTqQSmTkx2cQwqYUdYonknKyIY9h0JW7D6378jYfP7ArazJM/XPvgMC9f1wJbsFpbfX2SCKigQyLkZEqDEkZC6V/jtJMkvGGk9uZyvNUq/2HizYpET32tqk5gSotRm/388YcfKDN/PnW0fxoq+iCiFhbXTTt1wo2WycjZVl9trjjJqJd8ARF0OANb1ne8pDCgV+wufvKe7/3id/O1E8T88exjnz+0lGWvADwUqAIg1VKG72q3XFWprcX17qzzke4aEjpgAqSvObKnLwlUDX1/YzKLJ4796FdvbMFubXKrr9r9/rufPTwo4icG0T5F/yjy7WeHe1iIG94VLM7VlX6qCEgy8g9i1M9FXvzMJkhyFa5vMXiRS/D5qqueO/b4uX9p4naw/wDv1ZplvOGRpgAAAABJRU5ErkJggg==`;
+
+// src/components/styled/signInModalStyles.ts
+var COLOR_LIGHT_TEXT_MEDIUM = "#74777C";
+var ethosWalletTitleText = () => ({
+  fontSize: "18px",
+  lineHeight: "24px",
+  fontWeight: "600",
+  marginLeft: "10px"
+});
+var secondaryText = () => ({
+  color: "#6B7280",
+  fontSize: "0.875rem",
+  lineHeight: "1.25rem",
+  padding: "24px",
+  display: "flex",
+  flexDirection: "column",
+  gap: "12px"
+});
+var dialog = (isOpen) => ({
+  visibility: isOpen ? "" : "hidden",
+  position: "relative",
+  zIndex: "100"
+});
+var backdrop = (isOpen) => (
+  // fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity
+  {
+    position: "fixed",
+    top: "0px",
+    right: "0px",
+    bottom: "0px",
+    left: "0px",
+    backgroundColor: "rgb(107 114 128)",
+    opacity: isOpen ? ".75" : "0",
+    transition: "all 300ms ease-in-out"
+  }
+);
+var highlighted = () => ({
+  color: "#6D28D9"
+});
+var modalOuterWrapper = (isOpen) => (
+  // fixed z-10 inset-0 overflow-y-auto
+  {
+    position: "fixed",
+    zIndex: "99",
+    top: "0px",
+    right: "0px",
+    bottom: "0px",
+    left: "0px",
+    overflowY: "auto",
+    opacity: isOpen ? "1" : "0",
+    scale: isOpen ? "1" : ".95",
+    transition: "all 300ms ease-in-out"
+  }
+);
+var modalInnerWrapper = (width) => {
+  const styles = {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    minHeight: "100%",
+    padding: "1rem",
+    textAlign: "center"
+  };
+  const sm = {
+    padding: "0",
+    alignItems: "center"
+  };
+  return width < 640 /* sm */ ? styles : { ...styles, ...sm };
+};
+var dialogPanel = (width) => {
+  const styles = {
+    overflow: "hidden",
+    position: "relative",
+    backgroundColor: "#ffffff",
+    transitionProperty: "all",
+    borderRadius: "0.5rem",
+    boxShadow: "0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04)"
+  };
+  const sm = {
+    width: "360px"
+  };
+  return width < 640 /* sm */ ? styles : { ...styles, ...sm };
+};
+var topPanelStyle = () => ({
+  padding: "24px 24px 0px",
+  display: "flex",
+  flexDirection: "row",
+  justifyContent: "space-between",
+  alignItems: "center"
+});
+var closeStyle = () => ({
+  width: "24px",
+  height: "24px",
+  color: "#A0AEBA",
+  cursor: "pointer"
+});
+var backStyle = () => ({
+  color: COLOR_LIGHT_TEXT_MEDIUM,
+  cursor: "pointer",
+  display: "flex",
+  gap: "6px",
+  alignItems: "center"
+});
+var backStyleText = () => ({
+  fontSize: "16px",
+  lineHeight: "24px"
+});
+var headerStyle = (withIcon = false) => ({
+  padding: withIcon ? "24px 24px 32px" : "0 24px 32px",
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "center",
+  gap: "12px"
+});
+var headerLogosStyle = () => ({
+  display: "flex",
+  justifyContent: "center",
+  gap: "-6px"
+});
+var titleStyle = () => ({
+  fontSize: "24px",
+  fontWeight: "600",
+  lineHeight: "32px",
+  margin: "0"
+});
+var subTitleStyle = () => ({
+  fontSize: "16px",
+  fontWeight: "400",
+  lineHeight: "24px",
+  margin: "0",
+  color: COLOR_LIGHT_TEXT_MEDIUM
+});
+var strikeThroughOrContainer = () => ({
+  padding: "0px 24px 24px",
+  display: "flex",
+  flexDirection: "row",
+  gap: "12px",
+  justifyContent: "space-between",
+  alignItems: "center",
+  color: COLOR_LIGHT_TEXT_MEDIUM
+});
+var line = () => ({
+  height: "1px",
+  width: "100%",
+  background: "rgba(0, 0, 0, 0.12)",
+  borderRadius: "16px"
+});
+var emailInput = () => ({
+  boxSizing: "border-box",
+  border: "1px solid rgba(0, 0, 0, 0.08)",
+  borderRadius: "16px",
+  background: "#F2F2F2",
+  padding: "20px",
+  width: "100%"
+});
+var walletOptionContainer = (width) => {
+  const styles = {
+    padding: "0px 24px 24px",
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    gap: "12px"
+  };
+  const sm = {};
+  return width < 640 /* sm */ ? styles : { ...styles, ...sm };
+};
+var iconButton = (width, disabled = false, primary2 = false, noIcon = false) => {
+  const styles = {
+    textDecoration: "none",
+    fontWeight: primary2 ? "500" : "400",
+    boxSizing: "border-box",
+    display: "flex",
+    flexDirection: "row",
+    gap: "12px",
+    justifyContent: noIcon ? "center" : "space-between",
+    alignItems: "center",
+    padding: primary2 ? "20px 20px" : "16px 16px 16px 20px",
+    width: "100%",
+    background: primary2 ? "#6D28D9" : "#F2F2F2",
+    color: primary2 ? "white" : "black",
+    opacity: disabled ? 0.5 : 1,
+    cursor: disabled ? "not-allowed" : "pointer",
+    borderRadius: "16px",
+    flex: "none",
+    order: "0",
+    flexGrow: "0",
+    boxShadow: "0px 1px 2px rgba(0, 0, 0, 0.05)",
+    border: "none",
+    fontSize: "inherit"
+  };
+  const sm = {};
+  return width < 640 /* sm */ ? styles : { ...styles, ...sm };
+};
+var submitButtonContainer = () => ({
+  padding: "0px 24px 24px"
+});
+var loaderStyle = () => ({
+  display: "flex",
+  justifyContent: "center",
+  padding: "45px 0"
+});
+var walletExplanation = () => ({
+  padding: "6px 0",
+  color: "#666",
+  width: "100%",
+  fontSize: "smaller",
+  marginBottom: "12px"
+});
+
+// src/lib/useHandleElementWithIdClicked.ts
+var import_react = require("react");
+function useHandleElementWithIdClicked(clickId, onClickOutside) {
+  (0, import_react.useEffect)(() => {
+    function handleClickOutside(event2) {
+      if (event2.target.id === clickId) {
+        onClickOutside();
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, []);
+}
+
+// src/components/svg/EthosEnclosed.tsx
+var EthosEnclosed = ({ width = 24, color = "#6D28D9" }) => <svg width={width} height={width} viewBox="0 0 56 56" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="56" height="56" rx="16" fill={color} />
+  <path opacity="0.8" d="M17.9631 13H36.9268C37.7997 13 38.5073 13.7076 38.5073 14.5805V35.9802C38.5073 36.8531 37.7997 37.5607 36.9268 37.5607H17.9631C17.0902 37.5607 16.3826 36.8531 16.3826 35.9802V14.5805C16.3826 13.7076 17.0902 13 17.9631 13Z" stroke="url(#paint0_linear_514_2169)" strokeOpacity="0.9" strokeWidth="0.790251" />
+  <path d="M17.2471 14.0457L30.1651 20.0566C30.7225 20.316 31.0789 20.8749 31.0789 21.4896V42.6676C31.0789 43.8113 29.9018 44.5763 28.8566 44.112L15.9386 38.3725C15.3677 38.1189 14.9998 37.5528 14.9998 36.9281V15.4787C14.9998 14.3231 16.1994 13.5582 17.2471 14.0457Z" fill="white" fillOpacity="0.9" />
+  <path d="M42.9117 27.9093C43.0029 27.4813 43.219 27.0901 43.5329 26.7851C43.8467 26.4801 44.2441 26.2753 44.6746 26.1965L45.8205 25.9872L44.6745 25.7779H44.6746C44.2441 25.6991 43.8467 25.4943 43.5329 25.1893C43.219 24.8843 43.0029 24.4931 42.9117 24.0651L42.6596 22.8774L42.4074 24.0651C42.3162 24.4931 42.1001 24.8843 41.7862 25.1893C41.4724 25.4943 41.075 25.6992 40.6445 25.7779L39.4985 25.9872L40.6446 26.1965H40.6445C41.075 26.2753 41.4724 26.4801 41.7861 26.7851C42.1 27.0901 42.3162 27.4813 42.4073 27.9093L42.6595 29.097L42.9117 27.9093Z" fill="white" fillOpacity="0.9" />
+  <defs><linearGradient id="paint0_linear_514_2169" x1="38.5073" y1="19.5371" x2="27.4445" y2="25.0685" gradientUnits="userSpaceOnUse">
+    <stop stopColor="white" />
+    <stop offset="1" stopColor="white" stopOpacity="0" />
+  </linearGradient></defs>
+</svg>;
+var EthosEnclosed_default = EthosEnclosed;
+
+// src/components/svg/Ethos.tsx
+var Ethos = ({ width = 24, color = "#1e293b" }) => <svg
+  width={width}
+  height={width * 65 / 47}
+  viewBox="0 0 47 65"
+  fill="none"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <path
+    d="M6.00471 1H40.0029C42.7644 1 45.0029 3.23858 45.0029 6V44.8425C45.0029 47.604 42.7643 49.8425 40.0029 49.8425H6.0047C3.24328 49.8425 1.0047 47.604 1.0047 44.8425V6C1.0047 3.23858 3.24329 1 6.00471 1Z"
+    stroke={color}
+    strokeWidth="2"
+  />
+  <path
+    d="M6.68764 3.64648L30.6631 14.8026C32.0736 15.4589 32.9756 16.8735 32.9756 18.4292V58.6799C32.9756 61.5743 29.9966 63.5105 27.3515 62.3353L3.37601 51.683C1.93126 51.0411 1.00013 49.6085 1.00013 48.0276V7.27309C1.00013 4.34854 4.03609 2.41268 6.68764 3.64648Z"
+    fill={color}
+  />
+</svg>;
+var Ethos_default = Ethos;
+
+// src/components/styled/Header.tsx
+var Header = ({ title, subTitle, dappIcon, showEthos = false, children }) => {
+  return <div>
+    <div style={headerStyle(!!dappIcon)}>
+      <div style={headerLogosStyle()}>
+        {dappIcon && (typeof dappIcon === "string" ? <img src={dappIcon} /> : dappIcon)}
+        {showEthos && <Ethos_default />}
+      </div>
+      {title && <div style={titleStyle()}>{title}</div>}
+      {subTitle && <div style={subTitleStyle()}>{subTitle}</div>}
+    </div>
+    {children}
+  </div>;
+};
+var Header_default = Header;
+
+// src/components/styled/EmailSent.tsx
+var EmailSent = () => {
+  return <Header_default
+    title="Ethos sent you an email"
+    dappIcon={<EthosEnclosed_default width={60} />}
+  ><div style={secondaryText()}>
+    <p>An email has been sent to you with a link to login.</p>
+    <p>If you don't receive it, please check your spam folder or contact us at:</p>
+    <p>support@ethoswallet.xyz</p>
+  </div></Header_default>;
+};
+var EmailSent_default = EmailSent;
+
+// src/components/styled/Wallets.tsx
+var import_react2 = require("react");
+
+// src/components/styled/IconButton.tsx
+var IconButton = (props) => {
+  const { text, icon, width, disabled, primary: primary2, type, ...reactProps } = props;
+  return <button
+    style={iconButton(width, disabled, primary2, !icon)}
+    {...reactProps}
+    type={type}
+  >
+    <div>{text}</div>
+    {icon}
+  </button>;
+};
+var IconButton_default = IconButton;
+
+// src/components/styled/Wallets.tsx
+var Wallets = ({ wallets, selectWallet, width }) => {
+  const _connectExtension = (0, import_react2.useCallback)((e) => {
+    if (!selectWallet)
+      return;
+    let element = e.target;
+    let name;
+    while (!name && element.parentNode) {
+      name = element.dataset.name;
+      element = element.parentNode;
+    }
+    selectWallet(name);
+  }, []);
+  const icon = (0, import_react2.useCallback)((wallet) => {
+    const src = wallet.name === "Sui Wallet" ? "https://sui.io/favicon.png" : wallet.icon;
+    return <img src={src} height={32} width={32} />;
+  }, []);
+  return <div role="wallet-sign-in"><div style={walletOptionContainer(width)}>{wallets?.map(
+    (wallet, index) => <IconButton_default
+      key={`select-wallet-${index}`}
+      icon={icon(wallet)}
+      data-name={wallet.name}
+      text={wallet.name}
+      onClick={_connectExtension}
+      width={width}
+    />
+  )}</div></div>;
+};
+var Wallets_default = Wallets;
+
+// src/components/styled/Email.tsx
+var import_react3 = require("react");
+
+// src/lib/getConfiguration.ts
+var import_store2 = __toESM(require("store2"), 1);
+var getConfiguration = () => {
+  const ethosStore = import_store2.default.namespace("ethos");
+  const configuration = ethosStore("configuration");
+  return configuration || {};
+};
+var getConfiguration_default = getConfiguration;
+
+// src/lib/postIFrameMessage.ts
+var import_store24 = __toESM(require("store2"), 1);
+
+// src/lib/getIframe.ts
+var import_store23 = __toESM(require("store2"), 1);
+
+// src/lib/log.ts
+var import_store22 = __toESM(require("store2"), 1);
+var allowLog = (label) => {
+  const logStore = import_store22.default.namespace("log");
+  const allowed = logStore("allowed") || [];
+  if (allowed.includes(label))
+    return;
+  logStore("allowed", [...allowed, label]);
+  return `Logging enabled for ${label}. Call ethos.clearAllowLog() to turn off this logging.`;
+};
+var clearAllowLog = () => {
+  const logStore = import_store22.default.namespace("log");
+  logStore("allowed", []);
+};
+var log = (label, ...message) => {
+  const logStore = import_store22.default.namespace("log");
+  const allowed = logStore("allowed");
+  if (!allowed || !(allowed.includes(label) || allowed.includes("all"))) {
+    return;
+  }
+  console.log(label, ...message);
+};
+if (typeof window !== "undefined") {
+  ;
+  window.ethos = {
+    allowLog,
+    clearAllowLog
+  };
+}
+var log_default = log;
+
+// src/lib/getIframe.ts
+var getIframe = (show) => {
+  const { apiKey, walletAppUrl } = getConfiguration_default();
+  log_default("getIframe", "getIframe", apiKey, walletAppUrl);
+  if (!apiKey || !walletAppUrl)
+    return;
+  const iframeId = "ethos-wallet-iframe";
+  let scrollY = 0;
+  let iframe = document.getElementById(iframeId);
+  const close = () => {
+    if (!iframe)
+      return;
+    iframe.style.width = "1px";
+    iframe.style.height = "1px";
+  };
+  const queryParams = new URLSearchParams(window.location.search);
+  const accessToken = queryParams.get("access_token");
+  const refreshToken = queryParams.get("refresh_token");
+  let fullWalletAppUrl = walletAppUrl + `/wallet?apiKey=${apiKey}`;
+  if (accessToken && refreshToken) {
+    fullWalletAppUrl += `&access_token=${accessToken}&refresh_token=${refreshToken}`;
+    queryParams.delete("access_token");
+    queryParams.delete("refresh_token");
+    let fullPath = location.protocol + "//" + location.host + location.pathname;
+    if (queryParams.toString().length > 0) {
+      fullPath += "?" + queryParams.toString();
+    }
+    import_store23.default.namespace("auth")("access_token", accessToken);
+    import_store23.default.namespace("auth")("refresh_token", refreshToken);
+    window.history.pushState({}, "", fullPath);
+  } else {
+    const accessToken2 = import_store23.default.namespace("auth")("access_token");
+    const refreshToken2 = import_store23.default.namespace("auth")("refresh_token");
+    if (accessToken2 && refreshToken2) {
+      fullWalletAppUrl += `&access_token=${accessToken2}&refresh_token=${refreshToken2}`;
+    }
+  }
+  if (!iframe) {
+    log_default("getIframe", "Load Iframe", fullWalletAppUrl);
+    iframe = document.createElement("IFRAME");
+    iframe.src = fullWalletAppUrl;
+    iframe.id = iframeId;
+    iframe.style.border = "none";
+    iframe.style.position = "absolute";
+    iframe.style.top = scrollY - 1 + "px";
+    iframe.style.right = "60px";
+    iframe.style.width = "1px";
+    iframe.style.height = "1px";
+    iframe.style.zIndex = "99";
+    iframe.style.backgroundColor = "transparent";
+    iframe.setAttribute("allow", "payment; clipboard-read; clipboard-write");
+    document.body.appendChild(iframe);
+    window.addEventListener("message", (message) => {
+      if (message.origin === walletAppUrl) {
+        const { action } = message.data;
+        switch (action) {
+          case "close":
+            close();
+            break;
+          case "ready":
+            iframe.setAttribute("readyToReceiveMessages", "true");
+            const messageStore = import_store23.default.namespace("iframeMessages");
+            const messages = messageStore("messages") || [];
+            for (const message2 of messages) {
+              postIFrameMessage_default(message2);
+            }
+            messageStore("messages", null);
+            break;
+        }
+      }
+    });
+    window.addEventListener("scroll", () => {
+      scrollY = window.scrollY;
+      iframe.style.top = scrollY + "px";
+    });
+  }
+  if (show) {
+    iframe.style.width = "360px";
+    iframe.style.height = "600px";
+  } else if (show !== void 0) {
+    close();
+  }
+  return iframe;
+};
+var getIframe_default = getIframe;
+
+// src/lib/postIFrameMessage.ts
+var postIFrameMessage = (message) => {
+  const iframe = getIframe_default();
+  if (!iframe?.getAttribute("readyToReceiveMessages")) {
+    const messageStore = import_store24.default.namespace("iframeMessages");
+    const existingMessages = messageStore("messages") || [];
+    const result = messageStore("messages", [...existingMessages, message]);
+    log_default("iframe", "Storing iframe message", result);
+    return;
+  }
+  iframe?.contentWindow?.postMessage(message, "*");
+};
+var postIFrameMessage_default = postIFrameMessage;
+
+// src/lib/event.ts
+var event = async (eventProps) => {
+  postIFrameMessage_default({
+    action: "event",
+    data: eventProps
+  });
+};
+var event_default = event;
+
+// src/lib/login.ts
+var import_store28 = __toESM(require("store2"), 1);
+
+// src/lib/getWalletContents.ts
+var import_sui2 = require("@mysten/sui.js");
+
+// src/lib/bigNumber.ts
+var import_bignumber = __toESM(require("bignumber.js"), 1);
+var newBN = (value) => new import_bignumber.default(value);
+var sumBN = (balance, addition) => {
+  let bn = new import_bignumber.default(balance.toString());
+  let bnAddition = new import_bignumber.default(addition.toString());
+  return bn.plus(bnAddition);
+};
+var formatBalance = (balance, decimals = 9) => {
+  if (balance === void 0)
+    return "---";
+  let postfix = "";
+  let bn = new import_bignumber.default(balance.toString()).shiftedBy(-1 * decimals);
+  if (bn.gte(1e9)) {
+    bn = bn.shiftedBy(-9);
+    postfix = " B";
+  } else if (bn.gte(1e6)) {
+    bn = bn.shiftedBy(-6);
+    postfix = " M";
+  } else if (bn.gte(1e4)) {
+    bn = bn.shiftedBy(-3);
+    postfix = " K";
+  }
+  if (bn.gte(1)) {
+    bn = bn.decimalPlaces(3, import_bignumber.default.ROUND_DOWN);
+  } else {
+    bn = bn.decimalPlaces(6, import_bignumber.default.ROUND_DOWN);
+  }
+  return bn.toFormat() + postfix;
+};
+
+// src/lib/getBagNFT.ts
+var import_sui = require("@mysten/sui.js");
+var import_lodash = __toESM(require("lodash"), 1);
+var UrlDomainRegex = /0x2::dynamic_field::Field<(0x[a-f0-9]{39,40})::utils::Marker<(0x[a-f0-9]{39,40})::display::UrlDomain>, (0x[a-f0-9]{39,40})::display::UrlDomain>/;
+var DisplayDomainRegex = /0x2::dynamic_field::Field<(0x[a-f0-9]{39,40})::utils::Marker<(0x[a-f0-9]{39,40})::display::DisplayDomain>, (0x[a-f0-9]{39,40})::display::DisplayDomain>/;
+var ID_PATH = "reference.objectId";
+var BAG_ID_PATH = "data.fields.bag.fields.id.id";
+var LOGICAL_OWNER_PATH = "data.fields.logical_owner";
+var isTypeMatchRegex = (d, regex) => {
+  const { data } = d;
+  if ((0, import_sui.is)(data, import_sui.SuiObjectData)) {
+    const { content } = data;
+    if (content && "type" in content) {
+      return content.type.match(regex);
+    }
+  }
+  return false;
+};
+var parseDomains = (domains) => {
+  const response = {};
+  const urlDomain = domains.find((d) => isTypeMatchRegex(d, UrlDomainRegex));
+  const displayDomain = domains.find(
+    (d) => isTypeMatchRegex(d, DisplayDomainRegex)
+  );
+  if (urlDomain && (0, import_sui.getObjectFields)(urlDomain)) {
+    const url = (0, import_sui.getObjectFields)(urlDomain).value.fields.url;
+    response.url = ipfsConversion(url);
+  }
+  if (displayDomain && (0, import_sui.getObjectFields)(displayDomain)) {
+    response.description = (0, import_sui.getObjectFields)(displayDomain).value.fields.description;
+    response.name = (0, import_sui.getObjectFields)(displayDomain).value.fields.name;
+  }
+  return response;
+};
+var isBagNFT = (data) => {
+  return !!data.content && "fields" in data.content && "logical_owner" in data.content.fields && "bag" in data.content.fields;
+};
+var getBagNFT = async (provider, data) => {
+  if (!isBagNFT(data) || !import_lodash.default.has(data, ID_PATH) || !import_lodash.default.has(data, BAG_ID_PATH) || !import_lodash.default.has(data, LOGICAL_OWNER_PATH))
+    return data;
+  const id = import_lodash.default.get(data, ID_PATH);
+  const bagId = import_lodash.default.get(data, BAG_ID_PATH);
+  const owner = import_lodash.default.get(data, LOGICAL_OWNER_PATH);
+  const bagObjects = await provider.getDynamicFields({ parentId: bagId || "" });
+  const objectIds = bagObjects.data.map((bagObject) => bagObject.objectId);
+  const objects = await provider.multiGetObjects({
+    ids: objectIds,
+    options: {
+      showContent: true,
+      showDisplay: true,
+      showOwner: true,
+      showType: true
+    }
+  });
+  return {
+    id,
+    owner,
+    ...parseDomains(objects)
+  };
+};
+var getBagNFT_default = getBagNFT;
+
+// src/enums/Chain.ts
+var Chain = /* @__PURE__ */ ((Chain2) => {
+  Chain2["SUI_DEVNET"] = "sui:devnet";
+  Chain2["SUI_TESTNET"] = "sui:testnet";
+  Chain2["SUI_CUSTOM"] = "sui:custom";
+  return Chain2;
+})(Chain || {});
+
+// src/lib/constants.ts
+var primaryColor = "#6f53e4";
+var appBaseUrl = typeof window !== "undefined" && window.location.origin.indexOf("http://localhost") === 0 ? "http://localhost:3000" : "https://ethoswallet.onrender.com";
+var DEFAULT_NETWORK = "https://fullnode.devnet.sui.io/";
+var DEFAULT_FAUCET = "https://faucet.devnet.sui.io/";
+var DEFAULT_CHAIN = "sui:devnet" /* SUI_DEVNET */;
+
+// src/lib/getDisplay.ts
+var getDisplay = (display) => {
+  if (!display)
+    return;
+  if (display?.data && typeof display?.data === "object") {
+    return display.data;
+  }
+  if (!("error" in display))
+    return display;
+  return;
+};
+var getDisplay_default = getDisplay;
+
+// src/lib/getWalletContents.ts
+var ipfsConversion = (src) => {
+  if (!src)
+    return "";
+  if (src.indexOf("ipfs") === 0) {
+    src = `https://ipfs.io/ipfs/${src.substring(5)}`;
+  }
+  return src;
+};
+var empty = {
+  suiBalance: newBN(0),
+  nfts: [],
+  tokens: {},
+  objects: []
+};
+var getWalletContents = async ({ address: address2, network, existingContents }) => {
+  try {
+    const connection = new import_sui2.Connection({ fullnode: network || DEFAULT_NETWORK });
+    const provider = new import_sui2.JsonRpcProvider(connection);
+    if (!address2) {
+      return empty;
+    }
+    const objectInfos = await provider.getOwnedObjects({
+      owner: address2,
+      options: {
+        showType: true,
+        showOwner: true,
+        showContent: true,
+        showDisplay: true
+      }
+    });
+    if (objectInfos.data.length === 0) {
+      if (existingContents === empty) {
+        return null;
+      }
+      return empty;
+    }
+    const currentObjects = [];
+    let newObjectInfos = [];
+    if (existingContents?.objects && existingContents.objects.length > 0) {
+      for (const objectInfo of objectInfos.data) {
+        if (!objectInfo.data || objectInfo.error)
+          continue;
+        const existingObject = existingContents?.objects.find(
+          (existingObject2) => {
+            if (typeof objectInfo.data === "object" && typeof existingObject2.data === "object") {
+              return existingObject2.data.objectId === objectInfo.data.objectId && existingObject2.data.version === objectInfo.data.version;
+            } else {
+              return false;
+            }
+          }
+        );
+        if (existingObject) {
+          currentObjects.push(existingObject);
+        } else {
+          newObjectInfos.push(objectInfo);
+        }
+      }
+    } else {
+      newObjectInfos = objectInfos.data;
+    }
+    if (newObjectInfos.length === 0)
+      return null;
+    const newObjects = newObjectInfos;
+    const objects = currentObjects.concat(newObjects);
+    let suiBalance = newBN(0);
+    const nfts = [];
+    const tokens = {};
+    const convenenienceObjects = [];
+    for (const object of objects) {
+      const { data } = object;
+      if (!data)
+        continue;
+      const { display, content: { fields } } = data;
+      const safeDisplay = getDisplay_default(display);
+      try {
+        const typeStringComponents = (data.type || "").split("<");
+        const subtype = (typeStringComponents[1] || "").replace(/>/, "");
+        const typeComponents = typeStringComponents[0].split("::");
+        const type = typeComponents[typeComponents.length - 1];
+        const { name, description, ...extraFields } = fields ?? {};
+        convenenienceObjects.push({
+          ...object,
+          type: data?.type,
+          version: data?.version,
+          objectId: data?.objectId,
+          name,
+          description,
+          display: safeDisplay,
+          extraFields
+        });
+        if (type === "Coin") {
+          if (subtype === "0x2::sui::SUI") {
+            suiBalance = sumBN(suiBalance, fields.balance);
+          }
+          tokens[subtype] ||= {
+            balance: 0,
+            coins: []
+          };
+          tokens[subtype].balance = sumBN(tokens[subtype].balance, fields.balance);
+          tokens[subtype].coins.push({
+            objectId: data?.objectId,
+            type: data?.type,
+            balance: newBN(fields.balance),
+            digest: data?.digest,
+            version: data?.version,
+            display: safeDisplay
+          });
+        } else if (isBagNFT(object.data)) {
+          const bagNFT = await getBagNFT_default(provider, object.data);
+          if ("name" in bagNFT) {
+            nfts.push({
+              type: data?.type,
+              package: typeComponents[0],
+              chain: "Sui",
+              address: data?.objectId,
+              objectId: data?.objectId,
+              name: safeDisplay?.name ?? bagNFT.name,
+              description: safeDisplay?.name ?? bagNFT.description,
+              imageUri: ipfsConversion(safeDisplay?.image_url ?? bagNFT.url),
+              link: safeDisplay?.link,
+              creator: safeDisplay?.creator,
+              projectUrl: safeDisplay?.project_url,
+              display: safeDisplay,
+              module: typeComponents[1],
+              links: {
+                "Explorer": `https://explorer.sui.io/objects/${object?.objectId}`
+              }
+            });
+          }
+        } else {
+          const { url, image_url, image, ...remaining } = extraFields || {};
+          const safeUrl = ipfsConversion(safeDisplay?.image_url || url || image_url || image);
+          if (safeUrl) {
+            nfts.push({
+              type: data?.type,
+              package: typeComponents[0],
+              chain: "Sui",
+              address: data?.objectId,
+              objectId: data?.objectId,
+              name: safeDisplay?.name ?? name,
+              description: safeDisplay?.description ?? description,
+              imageUri: safeUrl,
+              link: safeDisplay?.link,
+              creator: safeDisplay?.creator,
+              projectUrl: safeDisplay?.project_url,
+              display: safeDisplay,
+              extraFields: remaining,
+              module: typeComponents[1],
+              links: {
+                "Explorer": `https://explorer.sui.io/objects/${object?.objectId}`
+              }
+            });
+          }
+        }
+      } catch (error) {
+        console.log("Error retrieving object", object, error);
+      }
+    }
+    return { suiBalance, tokens, nfts, objects: convenenienceObjects };
+  } catch (error) {
+    console.log("Error retrieving wallet contents", error);
+    return null;
+  }
+};
+var getWalletContents_default = getWalletContents;
+
+// src/lib/getEthosSigner.ts
+var import_store26 = __toESM(require("store2"), 1);
+
+// src/lib/activeUser.ts
+var activeUser = () => {
+  log_default("activeUser", "Calling Active User");
+  const { walletAppUrl, apiKey } = getConfiguration_default();
+  log_default("activeUser", "Configuration", walletAppUrl, apiKey);
+  const resolver = (resolve) => {
+    const listener = (message2) => {
+      log_default("activeUser", "Message Origin: ", message2.origin, walletAppUrl, message2);
+      if (message2.origin === walletAppUrl) {
+        const { action, data } = message2.data;
+        log_default("activeUser", "Message From Wallet", action, data);
+        if (action === "user" && data.apiKey === apiKey) {
+          window.removeEventListener("message", listener);
+          resolve(data?.user);
+        }
+      }
+    };
+    window.addEventListener("message", listener);
+    const message = { action: "activeUser" };
+    log_default("activeUser", "getIframe");
+    getIframe_default();
+    log_default('activeUser", "Post message to the iframe', message);
+    postIFrameMessage_default(message);
+  };
+  return new Promise(resolver);
+};
+var activeUser_default = activeUser;
+
+// src/lib/hostedInteraction.ts
+var import_store25 = __toESM(require("store2"), 1);
+var hostedInteraction = ({ id, action, data, onResponse, showWallet: showWallet2 = false }) => {
+  const { walletAppUrl } = getConfiguration_default();
+  const iframeListener = (message) => {
+    log_default("hostedInteraction", "response: ", message);
+    if (message.origin === walletAppUrl) {
+      const { approved, action: responseAction, data: responseData } = message.data;
+      if (responseAction !== action)
+        return;
+      onResponse({ approved, data: responseData });
+      window.removeEventListener("message", iframeListener);
+      getIframe_default(false);
+    }
+  };
+  window.addEventListener("message", iframeListener);
+  const ethosStore = import_store25.default.namespace("ethos");
+  const configuration = ethosStore("configuration");
+  const { network } = configuration;
+  log_default("hostedInteraction", "Posting interaction", id, action, data);
+  postIFrameMessage_default({ id, network, action, data });
+  getIframe_default(showWallet2);
+};
+var hostedInteraction_default = hostedInteraction;
+
+// src/lib/getEthosSigner.ts
+var getEthosSigner = async ({ defaultChain }) => {
+  const user = await activeUser_default();
+  const accounts = (user?.accounts || []).filter((account) => account.chain === "sui");
+  const currentAccount = accounts[0];
+  const signAndExecuteTransactionBlock = (input) => {
+    return new Promise((resolve, reject) => {
+      const transactionEventListener = ({ approved, data }) => {
+        if (approved) {
+          resolve(data.response);
+        } else {
+          reject({ error: data?.response?.error || "User rejected transaction." });
+        }
+      };
+      const serializedTransaction = input.transactionBlock.serialize();
+      const account = input.account ?? currentAccount.address;
+      const chain = input.chain ?? defaultChain ?? DEFAULT_CHAIN;
+      hostedInteraction_default({
+        action: "transaction",
+        data: {
+          input,
+          serializedTransaction,
+          account,
+          chain
+        },
+        onResponse: transactionEventListener,
+        showWallet: true
+      });
+    });
+  };
+  const signTransactionBlock = (input) => {
+    return new Promise((resolve, reject) => {
+      const transactionEventListener = ({ approved, data }) => {
+        if (approved) {
+          resolve(data.response);
+        } else {
+          reject({ error: data?.response?.error || "User rejected transaction." });
+        }
+      };
+      const serializedTransaction = input.transactionBlock.serialize();
+      const account = input.account ?? currentAccount.address;
+      const chain = input.chain ?? defaultChain ?? DEFAULT_CHAIN;
+      hostedInteraction_default({
+        action: "transaction",
+        data: {
+          input,
+          serializedTransaction,
+          account,
+          chain
+        },
+        onResponse: transactionEventListener,
+        showWallet: true
+      });
+    });
+  };
+  const requestPreapproval = () => {
+    return Promise.resolve(true);
+  };
+  const signMessage = (input) => {
+    return new Promise((resolve, reject) => {
+      const transactionEventListener = ({ approved, data }) => {
+        if (approved) {
+          resolve(data.response);
+        } else {
+          reject({ error: data?.response?.error || "User rejected signing." });
+        }
+      };
+      hostedInteraction_default({
+        action: "sign",
+        data: { ...input, signData: input.message },
+        onResponse: transactionEventListener,
+        showWallet: true
+      });
+    });
+  };
+  const disconnect = (fromWallet = false) => {
+    return new Promise((resolve) => {
+      const transactionEventListener = () => {
+        resolve(true);
+      };
+      hostedInteraction_default({
+        action: "logout",
+        data: {
+          fromWallet: typeof fromWallet === "boolean" ? fromWallet : false
+        },
+        onResponse: transactionEventListener
+      });
+      import_store26.default.namespace("auth")("access_token", null);
+    });
+  };
+  const logout2 = () => {
+    return disconnect(true);
+  };
+  return user ? {
+    type: "hosted" /* Hosted */,
+    name: "Ethos",
+    icon: dataIcon,
+    email: user.email,
+    getAddress: async () => currentAccount?.address,
+    accounts,
+    currentAccount,
+    signAndExecuteTransactionBlock,
+    signTransactionBlock,
+    requestPreapproval,
+    signMessage,
+    disconnect,
+    logout: logout2
+  } : null;
+};
+var getEthosSigner_default = getEthosSigner;
+var dataIcon = `data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzIiIGhlaWdodD0iMzIiIHZpZXdCb3g9IjAgMCAzMiAzMiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHJlY3Qgd2lkdGg9IjMyIiBoZWlnaHQ9IjMyIiByeD0iOCIgZmlsbD0iIzZEMjhEOSIvPgo8cGF0aCBvcGFjaXR5PSIwLjgiIGQ9Ik05LjEyMTg3IDYuODU3MDZIMTkuOTU4M0MyMC40NTcxIDYuODU3MDYgMjAuODYxNCA3LjI2MTQxIDIwLjg2MTQgNy43NjAyVjE5Ljk4ODZDMjAuODYxNCAyMC40ODc0IDIwLjQ1NzEgMjAuODkxOCAxOS45NTgzIDIwLjg5MThIOS4xMjE4N0M4LjYyMzA4IDIwLjg5MTggOC4yMTg3MiAyMC40ODc0IDguMjE4NzIgMTkuOTg4NlY3Ljc2MDJDOC4yMTg3MiA3LjI2MTQxIDguNjIzMDggNi44NTcwNiA5LjEyMTg3IDYuODU3MDZaIiBzdHJva2U9InVybCgjcGFpbnQwX2xpbmVhcl82OTlfMjY5OCkiIHN0cm9rZS13aWR0aD0iMC40NTE1NzIiLz4KPHBhdGggZD0iTTguNzEyNzQgNy40NTQ1OUwxNi4wOTQ1IDEwLjg4OTRDMTYuNDEyOSAxMS4wMzc2IDE2LjYxNjYgMTEuMzU3IDE2LjYxNjYgMTEuNzA4M1YyMy44MUMxNi42MTY2IDI0LjQ2MzUgMTUuOTQ0IDI0LjkwMDcgMTUuMzQ2OCAyNC42MzUzTDcuOTY1MDIgMjEuMzU1NkM3LjYzODgyIDIxLjIxMDcgNy40Mjg1OCAyMC44ODcyIDcuNDI4NTggMjAuNTMwM1Y4LjI3MzQzQzcuNDI4NTggNy42MTMxMSA4LjExNDA2IDcuMTc2MDIgOC43MTI3NCA3LjQ1NDU5WiIgZmlsbD0id2hpdGUiLz4KPHBhdGggZD0iTTIzLjM3ODIgMTUuMzc2N0MyMy40MzAzIDE1LjEzMjEgMjMuNTUzOCAxNC45MDg2IDIzLjczMzIgMTQuNzM0M0MyMy45MTI1IDE0LjU2IDI0LjEzOTYgMTQuNDQzIDI0LjM4NTYgMTQuMzk3OUwyNS4wNDA0IDE0LjI3ODRMMjQuMzg1NSAxNC4xNTg4SDI0LjM4NTZDMjQuMTM5NiAxNC4xMTM3IDIzLjkxMjUgMTMuOTk2NyAyMy43MzMyIDEzLjgyMjRDMjMuNTUzOCAxMy42NDgxIDIzLjQzMDMgMTMuNDI0NiAyMy4zNzgyIDEzLjE4TDIzLjIzNDEgMTIuNTAxM0wyMy4wOSAxMy4xOEMyMy4wMzc5IDEzLjQyNDYgMjIuOTE0NCAxMy42NDgxIDIyLjczNTEgMTMuODIyNEMyMi41NTU4IDEzLjk5NjcgMjIuMzI4NyAxNC4xMTM4IDIyLjA4MjcgMTQuMTU4OEwyMS40Mjc4IDE0LjI3ODRMMjIuMDgyNyAxNC4zOTc5SDIyLjA4MjdDMjIuMzI4NyAxNC40NDMgMjIuNTU1NyAxNC41NiAyMi43MzUgMTQuNzM0M0MyMi45MTQ0IDE0LjkwODYgMjMuMDM3OSAxNS4xMzIxIDIzLjA5IDE1LjM3NjdMMjMuMjM0MSAxNi4wNTU0TDIzLjM3ODIgMTUuMzc2N1oiIGZpbGw9IndoaXRlIi8+CjxkZWZzPgo8bGluZWFyR3JhZGllbnQgaWQ9InBhaW50MF9saW5lYXJfNjk5XzI2OTgiIHgxPSIyMC44NjE0IiB5MT0iMTAuNTkyNiIgeDI9IjE0LjUzOTgiIHkyPSIxMy43NTM0IiBncmFkaWVudFVuaXRzPSJ1c2VyU3BhY2VPblVzZSI+CjxzdG9wIHN0b3AtY29sb3I9IndoaXRlIi8+CjxzdG9wIG9mZnNldD0iMSIgc3RvcC1jb2xvcj0id2hpdGUiIHN0b3Atb3BhY2l0eT0iMCIvPgo8L2xpbmVhckdyYWRpZW50Pgo8L2RlZnM+Cjwvc3ZnPgo=`;
+
+// src/lib/initializeEthos.ts
+var import_store27 = __toESM(require("store2"), 1);
+var initializeEthos = (ethosConfiguration) => {
+  const ethosStore = import_store27.default.namespace("ethos");
+  log_default("initialize", "Ethos Configuration", ethosConfiguration);
+  ethosStore("configuration", ethosConfiguration);
+};
+var initializeEthos_default = initializeEthos;
+
+// src/lib/listenForMobileConnection.ts
+var listenForMobileConnection = async () => {
+  const { walletAppUrl } = getConfiguration_default();
+  const connectionEventListener = (message) => {
+    if (message.origin === walletAppUrl) {
+      const { action, data } = message.data;
+      if (action !== "connect")
+        return;
+      if (!data.address) {
+        return;
+      }
+      ;
+      window.removeEventListener("message", connectionEventListener);
+      const signer = {
+        currentAccount: { address: data.address }
+      };
+      const provider = {
+        getSigner: signer
+      };
+      log_default("mobile", "Mobile connection established", provider, signer);
+    }
+  };
+  window.removeEventListener("message", connectionEventListener);
+  window.addEventListener("message", connectionEventListener);
+};
+var listenForMobileConnection_default = listenForMobileConnection;
+
+// src/lib/lib.ts
+var lib = {
+  // showWallet,
+  // hideWallet,
+  // login,
+  // logout,
+  // transact,
+  // preapprove,
+  getWalletContents: getWalletContents_default,
+  // dripSui,
+  postIFrameMessage: postIFrameMessage_default,
+  getEthosSigner: getEthosSigner_default,
+  getConfiguration: getConfiguration_default,
+  initializeEthos: initializeEthos_default,
+  listenForMobileConnection: listenForMobileConnection_default
+};
+var lib_default = lib;
+
+// src/lib/login.ts
+var login = async ({ email, provider, apiKey }) => {
+  const { walletAppUrl, redirectTo } = lib_default.getConfiguration();
+  const userStore = import_store28.default.namespace("users");
+  if (provider) {
+    const returnTo = redirectTo ?? location.href;
+    const fullUrl = `${walletAppUrl}/auth?apiKey=${apiKey}&returnTo=${encodeURIComponent(returnTo)}`;
+    location.href = `${walletAppUrl}/socialauth?provider=${provider}&redirectTo=${encodeURIComponent(fullUrl)}`;
+    return;
+  }
+  return new Promise((resolve, _reject) => {
+    const loginEventListener = (message) => {
+      if (message.origin === walletAppUrl) {
+        const { action, data } = message.data;
+        if (action !== "login")
+          return;
+        window.removeEventListener("message", loginEventListener);
+        userStore("current", data);
+        resolve(data);
+      }
+    };
+    window.addEventListener("message", loginEventListener);
+    lib_default.postIFrameMessage({
+      action: "login",
+      data: {
+        email,
+        provider,
+        returnTo: redirectTo ?? window.location.href,
+        apiKey
+      }
+    });
+  });
+};
+var login_default = login;
+
+// src/components/styled/Email.tsx
+var Email = ({ setSigningIn, setEmailSent, width }) => {
+  const { apiKey } = getConfiguration_default();
+  const [email, setEmail] = (0, import_react3.useState)("");
+  const validEmail = (0, import_react3.useMemo)(() => {
+    if (!email)
+      return false;
+    if (email.length === 0)
+      return false;
+    return !!email.match(/(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9]))\.){3}(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9])|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])/);
+  }, [email]);
+  const sendEmail = (0, import_react3.useCallback)(async () => {
+    if (!validEmail)
+      return;
+    await login_default({ email, apiKey });
+    setEmail("");
+    setSigningIn(false);
+    setEmailSent(true);
+    event_default({ action: "send_email", category: "sign_in", label: email, value: 1 });
+  }, [validEmail, login_default, email, apiKey]);
+  const _handleChange = (0, import_react3.useCallback)((e) => {
+    setEmail(e.target.value);
+  }, []);
+  const onSubmit = (0, import_react3.useCallback)(async (e) => {
+    if (!validEmail) {
+      e.preventDefault();
+      return;
+    }
+    setSigningIn(true);
+    sendEmail();
+  }, [sendEmail]);
+  return <div role="email-sign-in">
+    <form onSubmit={onSubmit} style={walletOptionContainer(width)}>
+      <input
+        style={emailInput()}
+        type="email"
+        placeholder="Enter your email address..."
+        value={email}
+        onChange={_handleChange}
+      />
+      <IconButton_default
+        text="Sign In With Email"
+        type="submit"
+        width={width}
+        disabled={!validEmail}
+        primary={true}
+      />
+    </form>
+    {
+      /* <div style={{ display: 'none', marginLeft: "-12px" }}>
+          <ReCAPTCHA
+              sitekey={captchaSiteKey}
+              ref={captchaRef}
+              size="invisible"
+              onChange={sendEmail}
+          />
+      </div> */
+    }
+  </div>;
+};
+var Email_default = Email;
+
+// src/components/styled/FontProvider.tsx
+var FontProvider = ({ children }) => {
+  const styles = () => ({
+    fontFamily: "'Inter', sans-serif",
+    color: "black",
+    lineHeight: "1.5",
+    fontSize: "16px"
+  });
+  return <>
+    <link href="https://rsms.me/inter/inter.css" rel="stylesheet" />
+    <div style={styles()}>{children}</div>
+  </>;
+};
+var FontProvider_default = FontProvider;
+
+// src/components/styled/Dialog.tsx
+var Dialog = ({ isOpenAll, children }) => {
+  return <FontProvider_default><div style={dialog(isOpenAll)} role="dialog">
+    <div style={backdrop(isOpenAll)} />
+    {children}
+  </div></FontProvider_default>;
+};
+var Dialog_default = Dialog;
+
+// src/components/styled/ModalWrapper.tsx
+var ModalWrapper = ({ closeOnClickId, onClose, isOpenAll, width, back, children }) => {
+  return <div style={modalOuterWrapper(isOpenAll)}><div id={closeOnClickId} style={modalInnerWrapper(width)}><div style={dialogPanel(width)}>
+    <div style={topPanelStyle()}>
+      <span>{back && <span style={backStyle()} onClick={back}>
+        {"\u2190"}
+        <span style={backStyleText()}>Back</span>
+      </span>}</span>
+      <span style={closeStyle()} onClick={onClose}><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" /></svg></span>
+    </div>
+    {children}
+  </div></div></div>;
+};
+var ModalWrapper_default = ModalWrapper;
+
+// src/components/svg/InstallWalletIcon.tsx
+var InstallWalletIcon = ({ width = 60 }) => {
+  return <svg width={width} height={width} viewBox="0 0 60 60" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect x="1" y="1" width="58" height="58" rx="17" fill="#1A1C26" />
+    <path d="M17.0307 21.5C18.1258 20.5314 19.538 19.9977 21 20H39C40.5213 20 41.9107 20.5667 42.9693 21.5C42.8475 20.5332 42.377 19.6442 41.6462 18.9998C40.9153 18.3553 39.9744 17.9998 39 18H21C20.0256 17.9998 19.0847 18.3553 18.3538 18.9998C17.623 19.6442 17.1525 20.5332 17.0307 21.5ZM17.0307 25.5C18.1258 24.5314 19.538 23.9977 21 24H39C40.5213 24 41.9107 24.5667 42.9693 25.5C42.8475 24.5332 42.377 23.6442 41.6462 22.9998C40.9153 22.3553 39.9744 21.9998 39 22H21C20.0256 21.9998 19.0847 22.3553 18.3538 22.9998C17.623 23.6442 17.1525 24.5332 17.0307 25.5ZM21 26C19.9391 26 18.9217 26.4214 18.1716 27.1716C17.4214 27.9217 17 28.9391 17 30V38C17 39.0609 17.4214 40.0783 18.1716 40.8284C18.9217 41.5786 19.9391 42 21 42H39C40.0609 42 41.0783 41.5786 41.8284 40.8284C42.5786 40.0783 43 39.0609 43 38V30C43 28.9391 42.5786 27.9217 41.8284 27.1716C41.0783 26.4214 40.0609 26 39 26H34C33.7348 26 33.4804 26.1054 33.2929 26.2929C33.1054 26.4804 33 26.7348 33 27C33 27.7956 32.6839 28.5587 32.1213 29.1213C31.5587 29.6839 30.7956 30 30 30C29.2044 30 28.4413 29.6839 27.8787 29.1213C27.3161 28.5587 27 27.7956 27 27C27 26.7348 26.8946 26.4804 26.7071 26.2929C26.5196 26.1054 26.2652 26 26 26H21Z" fill="white" />
+    <rect x="1" y="1" width="58" height="58" rx="17" stroke="#060914" strokeWidth="2" />
+  </svg>;
+};
+var InstallWalletIcon_default = InstallWalletIcon;
+
+// src/components/svg/SuiEnclosed.tsx
+var SuiEnclosed = ({ width = 32 }) => {
+  return <svg width={width} height={width} viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect width="32" height="32" rx="8" fill="#81BAEB" />
+    <g clipPath="url(#clip0_315_6756)"><path fillRule="evenodd" clipRule="evenodd" d="M10.4932 22.2659C11.0635 23.2776 11.8925 24.1195 12.8953 24.7053C13.898 25.2912 15.0385 25.5999 16.1999 25.5999C17.3613 25.5999 18.5017 25.2912 19.5045 24.7053C20.5073 24.1195 21.3363 23.2776 21.9066 22.2659C22.4918 21.2523 22.7999 20.1025 22.7999 18.932C22.7999 17.7616 22.4918 16.6118 21.9066 15.5982L16.8874 6.80155C16.8187 6.67967 16.7188 6.57825 16.598 6.50767C16.4772 6.4371 16.3398 6.3999 16.1999 6.3999C16.06 6.3999 15.9226 6.4371 15.8018 6.50767C15.6809 6.57825 15.5811 6.67967 15.5123 6.80155L10.4932 15.5982C9.90796 16.6118 9.59985 17.7616 9.59985 18.932C9.59985 20.1025 9.90796 21.2523 10.4932 22.2659ZM14.786 10.9865L15.8561 9.11092C15.8905 9.04998 15.9404 8.99927 16.0008 8.96399C16.0612 8.9287 16.1299 8.9101 16.1999 8.9101C16.2698 8.9101 16.3385 8.9287 16.399 8.96399C16.4594 8.99927 16.5093 9.04998 16.5437 9.11092L20.6605 16.3263C21.0301 16.966 21.2592 17.6771 21.3326 18.4123C21.4061 19.1475 21.3221 19.8898 21.0864 20.59C21.0352 20.3514 20.9648 20.1172 20.8758 19.8899C20.3072 18.4377 19.0214 17.3171 17.0534 16.559C15.7004 16.0397 14.8368 15.276 14.4859 14.2886C14.0339 13.0166 14.506 11.6291 14.786 10.9865ZM12.9612 14.1847L11.7392 16.3263C11.2817 17.1186 11.0409 18.0174 11.0409 18.9323C11.0409 19.8472 11.2817 20.7459 11.7392 21.5382C12.1091 22.1934 12.6186 22.7591 13.2316 23.1952C13.8447 23.6312 14.5462 23.927 15.2864 24.0615C16.0266 24.1959 16.7874 24.1658 17.5146 23.9732C18.2419 23.7806 18.9178 23.4302 19.4944 22.947C19.8131 22.1324 19.8244 21.2296 19.5264 20.4072C19.1088 19.358 18.1034 18.5204 16.5383 17.9172C14.7692 17.2381 13.6199 16.178 13.1228 14.7672C13.0558 14.5769 13.0019 14.3823 12.9612 14.1847Z" fill="white" /></g>
+    <defs><clipPath id="clip0_315_6756"><rect width="19.2" height="19.2" fill="white" transform="translate(6.3999 6.3999)" /></clipPath></defs>
+  </svg>;
+};
+var SuiEnclosed_default = SuiEnclosed;
+
+// src/components/svg/EthosWalletIcon.tsx
+var EthosWalletIcon = () => {
+  return <svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect width="32" height="32" rx="8" fill="#6D28D9" />
+    <path opacity="0.8" d="M9.12187 6.85706H19.9583C20.4571 6.85706 20.8614 7.26141 20.8614 7.7602V19.9886C20.8614 20.4874 20.4571 20.8918 19.9583 20.8918H9.12187C8.62308 20.8918 8.21872 20.4874 8.21872 19.9886V7.7602C8.21872 7.26141 8.62308 6.85706 9.12187 6.85706Z" stroke="url(#paint0_linear_699_2698)" strokeWidth="0.451572" />
+    <path d="M8.71274 7.45459L16.0945 10.8894C16.4129 11.0376 16.6166 11.357 16.6166 11.7083V23.81C16.6166 24.4635 15.944 24.9007 15.3468 24.6353L7.96502 21.3556C7.63882 21.2107 7.42858 20.8872 7.42858 20.5303V8.27343C7.42858 7.61311 8.11406 7.17602 8.71274 7.45459Z" fill="white" />
+    <path d="M23.3782 15.3767C23.4303 15.1321 23.5538 14.9086 23.7332 14.7343C23.9125 14.56 24.1396 14.443 24.3856 14.3979L25.0404 14.2784L24.3855 14.1588H24.3856C24.1396 14.1137 23.9125 13.9967 23.7332 13.8224C23.5538 13.6481 23.4303 13.4246 23.3782 13.18L23.2341 12.5013L23.09 13.18C23.0379 13.4246 22.9144 13.6481 22.7351 13.8224C22.5558 13.9967 22.3287 14.1138 22.0827 14.1588L21.4278 14.2784L22.0827 14.3979H22.0827C22.3287 14.443 22.5557 14.56 22.735 14.7343C22.9144 14.9086 23.0379 15.1321 23.09 15.3767L23.2341 16.0554L23.3782 15.3767Z" fill="white" />
+    <defs><linearGradient id="paint0_linear_699_2698" x1="20.8614" y1="10.5926" x2="14.5398" y2="13.7534" gradientUnits="userSpaceOnUse">
+      <stop stopColor="white" />
+      <stop offset="1" stopColor="white" stopOpacity="0" />
+    </linearGradient></defs>
+  </svg>;
+};
+var EthosWalletIcon_default = EthosWalletIcon;
+
+// src/components/styled/InstallWallet.tsx
+var InstallWallet = ({ walletInfos, width }) => {
+  const icon = (data) => {
+    if (!data)
+      return <></>;
+    if (typeof data === "string") {
+      return <img src={data} height={32} width={32} />;
+    }
+    return data;
+  };
+  const installWallets = [
+    {
+      name: "Ethos Wallet",
+      icon: <EthosWalletIcon_default />,
+      link: "https://chrome.google.com/webstore/detail/ethos-wallet/mcbigmjiafegjnnogedioegffbooigli"
+    },
+    {
+      name: "Sui Wallet",
+      icon: <SuiEnclosed_default />,
+      link: "https://chrome.google.com/webstore/detail/sui-wallet/opcgpfmipidbgpenhmajoajpbobppdil"
+    },
+    ...walletInfos || []
+  ];
+  return <Header_default
+    dappIcon={<InstallWalletIcon_default />}
+    title="Install A Wallet"
+    subTitle="Wallets allow you to interact with, store, send, and receive digital assets."
+  ><div role="wallet-sign-in"><div style={walletOptionContainer(width)}>{installWallets?.map(
+    (installWallet, index) => <a
+      key={`install-wallet-${index}`}
+      style={iconButton(width)}
+      href={installWallet.link}
+      target="_blank"
+    >
+      {installWallet.name}
+      <div>{icon(installWallet.icon)}</div>
+    </a>
+  )}</div></div></Header_default>;
+};
+var InstallWallet_default = InstallWallet;
+
+// src/hooks/useModal.ts
+var import_react5 = require("react");
+
+// src/components/ConnectContext.tsx
+var import_react4 = require("react");
+var defaultContents = {
+  init: () => {
+  }
+};
+var ConnectContext = (0, import_react4.createContext)(defaultContents);
+var ConnectContext_default = ConnectContext;
+
+// src/hooks/useModal.ts
+var useModal = () => {
+  const { modal } = (0, import_react5.useContext)(ConnectContext_default);
+  return modal;
+};
+var useModal_default = useModal;
+
+// src/hooks/useWallet.ts
+var import_react6 = require("react");
+
+// src/enums/EthosConnectStatus.ts
+var EthosConnectStatus = /* @__PURE__ */ ((EthosConnectStatus2) => {
+  EthosConnectStatus2["Loading"] = "loading";
+  EthosConnectStatus2["NoConnection"] = "no_connection";
+  EthosConnectStatus2["Connected"] = "connected";
+  return EthosConnectStatus2;
+})(EthosConnectStatus || {});
+
+// src/hooks/useWallet.ts
+var useWallet = () => {
+  const { wallet } = (0, import_react6.useContext)(ConnectContext_default);
+  return wallet ?? { status: "loading" /* Loading */, provider: null, setAltAccount: () => {
+  } };
+};
+var useWallet_default = useWallet;
+
+// src/hooks/useWindowDimensions.ts
+var import_react7 = require("react");
+function getWindowDimensions() {
+  if (typeof window === "undefined")
+    return { width: 0, height: 0 };
+  const { innerWidth: width, innerHeight: height } = window;
+  return {
+    width,
+    height
+  };
+}
+function useWindowDimensions() {
+  const [windowDimensions, setWindowDimensions] = (0, import_react7.useState)(
+    { width: 0, height: 0 }
+  );
+  (0, import_react7.useEffect)(() => {
+    setWindowDimensions(getWindowDimensions());
+    function handleResize() {
+      setWindowDimensions(getWindowDimensions());
+    }
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+  return windowDimensions;
+}
+
+// src/hooks/hooks.ts
+var hooks = {
+  useModal: useModal_default,
+  useWallet: useWallet_default,
+  useWindowDimensions
+};
+var hooks_default = hooks;
+
+// src/components/styled/MobileWallet.tsx
+var MobileWallet = () => {
+  return <div role="wallet-sign-in">
+    <span style={ethosWalletTitleText()}>Connect A Mobile Wallet</span>
+    <div style={walletExplanation()}><p>There are no mobile wallets yet on Sui.</p></div>
+  </div>;
+};
+var MobileWallet_default = MobileWallet;
+
+// src/components/styled/Or.tsx
+var Or = () => {
+  return <div style={strikeThroughOrContainer()}>
+    <div style={line()} />
+    {"or"}
+    <div style={line()} />
+  </div>;
+};
+var Or_default = Or;
+
+// src/components/styled/SignInModal.tsx
+function showSignInModal() {
+  window.ethosInternal.showSignInModal();
+}
+function hideSignInModal() {
+  window.ethosInternal.hideSignInModal();
+}
+var SignInModal = ({
+  connectMessage,
+  dappName,
+  dappIcon,
+  hideEmailSignIn,
+  hideWalletSignIn,
+  externalContext,
+  preferredWallets
+}) => {
+  const { wallets, selectWallet } = externalContext?.wallet || hooks_default.useWallet();
+  const { isModalOpen, openModal, closeModal } = externalContext?.modal || hooks_default.useModal();
+  const [isOpenAll, setIsOpenAll] = (0, import_react8.useState)(isModalOpen);
+  const [signingIn, setSigningIn] = (0, import_react8.useState)(false);
+  const [emailSent, setEmailSent] = (0, import_react8.useState)(false);
+  const { width } = hooks_default.useWindowDimensions();
+  const closeOnClickId = "ethos-close-on-click";
+  const [showEmail, setShowEmail] = (0, import_react8.useState)(false);
+  const [showMobile, setShowMobile] = (0, import_react8.useState)(false);
+  const [showInstallWallet, setShowInstallWallet] = (0, import_react8.useState)(false);
+  const [safeDappName, setSafeDappName] = (0, import_react8.useState)(dappName);
+  const [safeWallets, setSafeWallets] = (0, import_react8.useState)();
+  useHandleElementWithIdClicked(closeOnClickId, closeModal);
+  (0, import_react8.useEffect)(() => {
+    window.ethosInternal ||= {};
+    window.ethosInternal.showSignInModal = () => {
+      openModal();
+    };
+    window.ethosInternal.hideSignInModal = () => {
+      closeModal();
+    };
+    setIsOpenAll(isModalOpen);
+  }, [isModalOpen, setIsOpenAll, openModal, closeModal]);
+  (0, import_react8.useEffect)(() => {
+    if (hideEmailSignIn && hideWalletSignIn) {
+      throw new Error("hideEmailSignIn and hideWalletSignIn cannot both be true");
+    }
+  }, [hideEmailSignIn, hideWalletSignIn]);
+  (0, import_react8.useEffect)(() => {
+    if (!safeDappName) {
+      setSafeDappName(document.title);
+    }
+  }, [safeDappName]);
+  (0, import_react8.useEffect)(() => {
+    let safeWallets2 = wallets || [];
+    if (preferredWallets && preferredWallets.length > 0) {
+      safeWallets2 = safeWallets2.sort(
+        (a, b) => {
+          let aIndex = preferredWallets.indexOf(a.name);
+          if (aIndex === -1) {
+            aIndex = safeWallets2.length;
+          }
+          let bIndex = preferredWallets.indexOf(b.name);
+          if (bIndex === -1) {
+            bIndex = safeWallets2.length;
+          }
+          return aIndex - bIndex;
+        }
+      );
+    }
+    log_default("preferredWallets", preferredWallets, safeWallets2);
+    setSafeWallets(safeWallets2);
+  }, [wallets, preferredWallets, log_default]);
+  const _toggleInstallWallet = (0, import_react8.useCallback)(() => {
+    setShowInstallWallet((prev) => !prev);
+  }, []);
+  const _toggleEmail = (0, import_react8.useCallback)(() => {
+    setShowEmail((prev) => !prev);
+  }, []);
+  const _reset = (0, import_react8.useCallback)(() => {
+    setShowInstallWallet(false);
+    setShowMobile(false);
+    setShowEmail(false);
+  }, []);
+  const safeConnectMessage = (0, import_react8.useMemo)(() => {
+    if (connectMessage)
+      return connectMessage;
+    if (!safeDappName) {
+      return <></>;
+    }
+    return <>
+      {"Connect to "}
+      <span style={highlighted()}>{safeDappName}</span>
+    </>;
+  }, [safeDappName, connectMessage]);
+  const modalContent = (0, import_react8.useMemo)(() => {
+    if (!safeWallets) {
+      return <></>;
+    }
+    if (showMobile) {
+      return <MobileWallet_default />;
+    }
+    if (showInstallWallet || hideEmailSignIn && safeWallets.length === 0) {
+      return <InstallWallet_default width={width} />;
+    }
+    if (hideWalletSignIn) {
+      return <Email_default
+        setSigningIn={setSigningIn}
+        setEmailSent={setEmailSent}
+        width={width}
+      />;
+    }
+    if (!showEmail && safeWallets.length > 0)
+      return <Header_default
+        title={safeConnectMessage}
+        dappIcon={dappIcon}
+        subTitle="Choose from your installed wallets"
+      >
+        <Wallets_default
+          wallets={safeWallets}
+          selectWallet={selectWallet}
+          width={width}
+        />
+        {!hideEmailSignIn && <>
+          <Or_default />
+          <div style={submitButtonContainer()}><IconButton_default
+            text="Sign In With Email"
+            onClick={_toggleEmail}
+            width={width}
+            primary={true}
+          /></div>
+        </>}
+      </Header_default>;
+    return <Header_default
+      title={safeConnectMessage}
+      dappIcon={dappIcon}
+      subTitle={`Log in to ${safeDappName}`}
+    >
+      <Email_default
+        setSigningIn={setSigningIn}
+        setEmailSent={setEmailSent}
+        width={width}
+      />
+      {!hideWalletSignIn && <>
+        <Or_default />
+        <div style={submitButtonContainer()}>{safeWallets.length > 0 ? <IconButton_default
+          icon={<WalletsIcon_default />}
+          text="Select One Of Your Wallets"
+          onClick={_toggleEmail}
+          width={width}
+        /> : <IconButton_default
+          icon={<WalletsIcon_default />}
+          text="Install A Wallet"
+          onClick={_toggleInstallWallet}
+          width={width}
+        />}</div>
+      </>}
+    </Header_default>;
+  }, [safeConnectMessage, safeDappName, hideEmailSignIn, hideWalletSignIn, safeWallets, showEmail, showMobile, showInstallWallet]);
+  const subpage = (0, import_react8.useMemo)(() => {
+    return showMobile || showInstallWallet;
+  }, [showMobile, showInstallWallet]);
+  const loader = (0, import_react8.useMemo)(() => <div style={loaderStyle()}><Loader_default width={50} /></div>, []);
+  return <Dialog_default isOpenAll={isOpenAll}><ModalWrapper_default
+    closeOnClickId={closeOnClickId}
+    onClose={closeModal}
+    isOpenAll={isOpenAll}
+    width={width}
+    back={subpage ? _reset : null}
+  >{emailSent ? <EmailSent_default /> : signingIn ? loader : modalContent}</ModalWrapper_default></Dialog_default>;
+};
+var SignInModal_default = SignInModal;
+
+// src/hooks/useContext.ts
+var import_react12 = require("react");
+
+// src/hooks/useAccount.ts
+var import_react9 = require("react");
+var useAccount = (signer, network) => {
+  const [altAccount, setAltAccount] = (0, import_react9.useState)();
+  const [account, setAccount] = (0, import_react9.useState)({});
+  const latestNetwork = (0, import_react9.useRef)(network);
+  const existingContents = (0, import_react9.useRef)();
+  (0, import_react9.useEffect)(() => {
+    if (!signer)
+      return;
+    latestNetwork.current = network;
+    const initAccount = async () => {
+      const address2 = altAccount?.address ?? signer.currentAccount?.address;
+      if (!address2) {
+        return;
+      }
+      setAccount((prev) => {
+        if (prev.address === address2)
+          return prev;
+        return { ...prev, address: address2 };
+      });
+      const contents = await getWalletContents_default({
+        address: address2,
+        network,
+        existingContents: existingContents.current
+      });
+      if (!contents || network !== latestNetwork.current || JSON.stringify(existingContents.current) === JSON.stringify(contents))
+        return;
+      existingContents.current = contents;
+      setAccount((prev) => ({ ...prev, contents }));
+    };
+    initAccount();
+    const interval = setInterval(initAccount, 5e3);
+    return () => clearInterval(interval);
+  }, [network, signer, altAccount]);
+  return { account, altAccount, setAltAccount };
+};
+var useAccount_default = useAccount;
+
+// src/hooks/useConnect.ts
+var import_react11 = require("react");
+
+// src/hooks/useWalletKit.ts
+var import_react10 = require("react");
+var import_wallet_kit_core = require("@mysten/wallet-kit-core");
+var import_wallet_adapter_all_wallets = require("@mysten/wallet-adapter-all-wallets");
+var useWalletKit = ({ defaultChain, configuredAdapters, features, enableUnsafeBurner, preferredWallets, storageAdapter, storageKey, disableAutoConnect }) => {
+  const adapters = (0, import_react10.useMemo)(
+    () => configuredAdapters ?? [
+      new import_wallet_adapter_all_wallets.WalletStandardAdapterProvider({ features }),
+      ...enableUnsafeBurner ? [new import_wallet_adapter_all_wallets.UnsafeBurnerWalletAdapter()] : []
+    ],
+    [configuredAdapters]
+  );
+  const walletKitRef = (0, import_react10.useRef)(null);
+  if (!walletKitRef.current) {
+    walletKitRef.current = (0, import_wallet_kit_core.createWalletKitCore)({
+      adapters,
+      preferredWallets,
+      storageAdapter,
+      storageKey
+    });
+  }
+  const { wallets, status, currentWallet, accounts, currentAccount } = (0, import_react10.useSyncExternalStore)(
+    walletKitRef.current.subscribe,
+    walletKitRef.current.getState,
+    walletKitRef.current.getState
+  );
+  (0, import_react10.useEffect)(() => {
+    if (!disableAutoConnect) {
+      walletKitRef.current?.autoconnect();
+    }
+  }, [status, wallets]);
+  const { autoconnect, ...walletFunctions } = walletKitRef.current;
+  const signAndExecuteTransactionBlock = (0, import_react10.useCallback)((input) => {
+    if (!currentWallet || !currentAccount) {
+      throw new Error("No wallet connect to sign message");
+    }
+    const account = input.account || currentAccount;
+    const chain = input.chain || defaultChain || DEFAULT_CHAIN;
+    return currentWallet.signAndExecuteTransactionBlock({
+      ...input,
+      account,
+      chain
+    });
+  }, [currentWallet, currentAccount, defaultChain]);
+  const signTransactionBlock = (0, import_react10.useCallback)((input) => {
+    if (!currentWallet || !currentAccount) {
+      throw new Error("No wallet connect to sign message");
+    }
+    const account = input.account || currentAccount;
+    const chain = input.chain || defaultChain || DEFAULT_CHAIN;
+    return currentWallet.signTransactionBlock({
+      ...input,
+      account,
+      chain
+    });
+  }, [currentWallet, currentAccount, defaultChain]);
+  const signMessage = (0, import_react10.useCallback)((input) => {
+    if (!currentWallet || !currentAccount) {
+      throw new Error("No wallet connect to sign message");
+    }
+    const account = input.account || currentAccount;
+    const message = typeof input.message === "string" ? new Uint8Array(Buffer.from(input.message, "utf8")) : input.message;
+    return currentWallet.signMessage({
+      ...input,
+      message,
+      account
+    });
+  }, [currentWallet, currentAccount]);
+  const requestPreapproval = (0, import_react10.useCallback)(async (preapproval) => {
+    if (!currentWallet || !currentAccount) {
+      throw new Error("No wallet connect to preapprove transactions");
+    }
+    const ethosWallet = window.ethosWallet;
+    if (!ethosWallet || currentWallet.name !== "Ethos Wallet") {
+      console.log("Wallet does not support preapproval");
+      return false;
+    }
+    if (!preapproval.address) {
+      preapproval.address = currentAccount.address;
+    }
+    if (!preapproval.chain) {
+      preapproval.chain = defaultChain ?? DEFAULT_CHAIN;
+    }
+    return ethosWallet.requestPreapproval(preapproval);
+  }, [currentWallet, currentAccount, defaultChain]);
+  const constructedSigner = (0, import_react10.useMemo)(() => {
+    if (!currentWallet || !currentAccount)
+      return null;
+    return {
+      type: "extension" /* Extension */,
+      name: currentWallet.name,
+      icon: currentWallet.name === "Sui Wallet" ? "https://sui.io/favicon.png" : currentWallet.icon,
+      getAddress: async () => currentAccount?.address,
+      accounts,
+      currentAccount,
+      signAndExecuteTransactionBlock,
+      signTransactionBlock,
+      requestPreapproval,
+      signMessage,
+      disconnect: () => {
+        currentWallet.disconnect();
+        walletKitRef.current?.disconnect();
+      }
+    };
+  }, [currentWallet, accounts, currentAccount, signAndExecuteTransactionBlock, requestPreapproval, signMessage]);
+  return {
+    wallets,
+    status,
+    signer: constructedSigner,
+    ...walletFunctions
+  };
+};
+var useWalletKit_default = useWalletKit;
+
+// src/hooks/useConnect.ts
+var import_sui3 = require("@mysten/sui.js");
+var import_wallet_kit_core2 = require("@mysten/wallet-kit-core");
+var useConnect = (ethosConfiguration, onWalletConnected) => {
+  const signerFound = (0, import_react11.useRef)(false);
+  const methodsChecked = (0, import_react11.useRef)({
+    "ethos": false,
+    // 'mobile': false,
+    "extension": false
+  });
+  const [providerAndSigner, setProviderAndSigner] = (0, import_react11.useState)({
+    provider: null,
+    signer: null
+  });
+  const {
+    wallets,
+    status: suiStatus,
+    signer: suiSigner,
+    getState,
+    connect
+  } = useWalletKit_default({
+    defaultChain: ethosConfiguration?.chain ?? DEFAULT_CHAIN,
+    preferredWallets: ethosConfiguration?.preferredWallets,
+    disableAutoConnect: ethosConfiguration?.disableAutoConnect
+  });
+  const disconnect = (0, import_react11.useCallback)(() => {
+    signerFound.current = false;
+    methodsChecked.current = {
+      "ethos": false,
+      // 'mobile': false,
+      "extension": false
+    };
+    setProviderAndSigner((prev) => ({
+      ...prev,
+      signer: null
+    }));
+  }, []);
+  (0, import_react11.useEffect)(() => {
+    signerFound.current = false;
+    methodsChecked.current = {
+      "ethos": false,
+      // 'mobile': false,
+      "extension": false
+    };
+  }, [ethosConfiguration]);
+  (0, import_react11.useEffect)(() => {
+    const { provider, signer } = providerAndSigner;
+    if (!provider && !signer)
+      return;
+    const extensionState = getState();
+    if (extensionState.isConnecting || extensionState.isError)
+      return;
+    onWalletConnected && onWalletConnected(providerAndSigner);
+  }, [suiStatus, providerAndSigner, onWalletConnected, getState]);
+  const checkSigner = (0, import_react11.useCallback)((signer, type) => {
+    log_default("useConnect", "trying to set providerAndSigner", type, signerFound.current, methodsChecked.current);
+    if (signerFound.current)
+      return;
+    if (type) {
+      methodsChecked.current[type] = true;
+    }
+    const allMethodsChecked = !Object.values(methodsChecked.current).includes(false);
+    if (!signer && !allMethodsChecked)
+      return;
+    signerFound.current = !!signer;
+    const network = typeof ethosConfiguration?.network === "string" ? ethosConfiguration.network : DEFAULT_NETWORK;
+    const connection = new import_sui3.Connection({ fullnode: network });
+    const provider = new import_sui3.JsonRpcProvider(connection);
+    if (signer) {
+      const _disconnect = signer?.disconnect;
+      signer.disconnect = () => {
+        _disconnect();
+        disconnect();
+      };
+    }
+    setProviderAndSigner({ provider, signer });
+  }, [disconnect]);
+  (0, import_react11.useEffect)(() => {
+    if (suiStatus === import_wallet_kit_core2.WalletKitCoreConnectionStatus.DISCONNECTED) {
+      methodsChecked.current["extension"] = false;
+      signerFound.current = false;
+      setProviderAndSigner((prev) => ({
+        ...prev,
+        signer: null
+      }));
+    }
+  }, [suiStatus]);
+  (0, import_react11.useEffect)(() => {
+    if (!ethosConfiguration)
+      return;
+    log_default("mobile", "listening to mobile connection from EthosConnectProvider");
+  }, [checkSigner, ethosConfiguration]);
+  (0, import_react11.useEffect)(() => {
+    if (!ethosConfiguration)
+      return;
+    const state = getState();
+    log_default("useConnect", "Setting providerAndSigner extension", state);
+    if (state.isConnecting || state.isError)
+      return;
+    checkSigner(suiSigner, "extension");
+  }, [suiStatus, getState, checkSigner, suiSigner, ethosConfiguration]);
+  (0, import_react11.useEffect)(() => {
+    if (!ethosConfiguration)
+      return;
+    if (!ethosConfiguration.apiKey) {
+      log_default("useConnect", "Setting null providerAndSigner ethos");
+      checkSigner(null, "ethos");
+      return;
+    }
+    const fetchEthosSigner = async () => {
+      const signer = await lib_default.getEthosSigner({ defaultChain: ethosConfiguration.chain ?? DEFAULT_CHAIN });
+      log_default("useConnect", "Setting providerAndSigner ethos", signer);
+      checkSigner(signer, "ethos");
+    };
+    fetchEthosSigner();
+  }, [checkSigner, ethosConfiguration]);
+  return { wallets, providerAndSigner, connect, getState };
+};
+var useConnect_default = useConnect;
+
+// src/hooks/useContext.ts
+var DEFAULT_CONFIGURATION = {
+  network: DEFAULT_NETWORK,
+  chain: DEFAULT_CHAIN,
+  walletAppUrl: "https://ethoswallet.xyz"
+};
+var useContext3 = ({ configuration, onWalletConnected }) => {
+  const [ethosConfiguration, setEthosConfiguration] = (0, import_react12.useState)({
+    ...DEFAULT_CONFIGURATION,
+    ...configuration
+  });
+  const [isModalOpen, setIsModalOpen] = (0, import_react12.useState)(false);
+  const init = (0, import_react12.useCallback)((config) => {
+    log_default("EthosConnectProvider", "EthosConnectProvider Configuration:", config);
+    const fullConfiguration = {
+      ...DEFAULT_CONFIGURATION,
+      ...config
+    };
+    lib_default.initializeEthos(fullConfiguration);
+    setEthosConfiguration((prev) => {
+      if (JSON.stringify(fullConfiguration) !== JSON.stringify(prev)) {
+        return fullConfiguration;
+      } else {
+        return prev;
+      }
+    });
+  }, []);
+  (0, import_react12.useEffect)(() => {
+    lib_default.initializeEthos(ethosConfiguration);
+  }, [ethosConfiguration]);
+  (0, import_react12.useEffect)(() => {
+    if (!configuration)
+      return;
+    if (JSON.stringify(ethosConfiguration) === JSON.stringify(configuration))
+      return;
+    init(configuration);
+  }, [ethosConfiguration, configuration]);
+  const _onWalletConnected = (0, import_react12.useCallback)((providerAndSigner2) => {
+    setIsModalOpen(false);
+    onWalletConnected && onWalletConnected(providerAndSigner2);
+  }, [onWalletConnected]);
+  const {
+    wallets,
+    connect: selectWallet,
+    providerAndSigner,
+    getState
+  } = useConnect_default(ethosConfiguration, _onWalletConnected);
+  const {
+    account: { address: address2, contents },
+    altAccount,
+    setAltAccount
+  } = useAccount_default(providerAndSigner.signer, ethosConfiguration?.network ?? DEFAULT_NETWORK);
+  const modal = (0, import_react12.useMemo)(() => {
+    const openModal = () => {
+      setIsModalOpen(true);
+    };
+    const closeModal = () => {
+      setIsModalOpen(false);
+    };
+    return {
+      isModalOpen,
+      openModal,
+      closeModal
+    };
+  }, [isModalOpen, setIsModalOpen]);
+  const wallet = (0, import_react12.useMemo)(() => {
+    const { provider, signer } = providerAndSigner;
+    const extensionState = getState();
+    let status;
+    if (signer?.type === "hosted") {
+      status = "connected" /* Connected */;
+    } else if (extensionState.isConnecting) {
+      status = "loading" /* Loading */;
+    } else if (provider && extensionState.isConnected) {
+      status = "connected" /* Connected */;
+    } else {
+      status = "no_connection" /* NoConnection */;
+    }
+    const context = {
+      status,
+      wallets: wallets.map((w) => ({
+        ...w,
+        name: w.name,
+        icon: w.icon
+      })),
+      selectWallet,
+      provider,
+      altAccount,
+      setAltAccount
+    };
+    if (signer && address2) {
+      context.wallet = {
+        ...signer,
+        address: address2,
+        contents
+      };
+    }
+    return context;
+  }, [
+    wallets,
+    selectWallet,
+    address2,
+    altAccount,
+    setAltAccount,
+    providerAndSigner,
+    contents,
+    ethosConfiguration
+  ]);
+  (0, import_react12.useEffect)(() => {
+    if (isModalOpen) {
+      document.getElementsByTagName("html").item(0)?.setAttribute("style", "overflow: hidden;");
+    } else {
+      document.getElementsByTagName("html").item(0)?.setAttribute("style", "");
+    }
+  }, [isModalOpen]);
+  const value = (0, import_react12.useMemo)(() => ({
+    wallet,
+    modal,
+    providerAndSigner
+  }), [wallet, modal, providerAndSigner]);
+  return { ...value, ethosConfiguration, init };
+};
+var useContext_default = useContext3;
+
+// src/components/EthosConnectProvider.tsx
+var EthosConnectProvider = ({ ethosConfiguration, onWalletConnected, connectMessage, dappName, dappIcon, children }) => {
+  const context = useContext_default({ configuration: ethosConfiguration || {}, onWalletConnected });
+  return <ConnectContext_default.Provider value={context}>
+    {children}
+    <SignInModal_default
+      isOpen={context.modal?.isModalOpen || false}
+      hideEmailSignIn={context.ethosConfiguration?.hideEmailSignIn || false}
+      hideWalletSignIn={context.ethosConfiguration?.hideWalletSignIn || false}
+      connectMessage={connectMessage}
+      dappName={dappName}
+      dappIcon={dappIcon}
+      preferredWallets={ethosConfiguration?.preferredWallets}
+    />
+  </ConnectContext_default.Provider>;
+};
+var EthosConnectProvider_default = EthosConnectProvider;
+
+// src/components/styled/SignInButton.tsx
+var import_react13 = require("react");
+
+// src/components/headless/WorkingButton.tsx
+var WorkingButton = (props) => {
+  const { children, isWorking, workingComponent, ...reactProps } = props;
+  return <button {...reactProps}>{isWorking ? workingComponent || <span className="block p-2"><Loader_default width={32} /></span> : <>{children}</>}</button>;
+};
+var WorkingButton_default = WorkingButton;
+
+// src/components/styled/SignInButton.tsx
+var SignInButton = (props) => {
+  const { children, onClick, externalContext, ...reactProps } = props;
+  const { openModal } = externalContext?.modal || useModal_default();
+  const _onClick = (0, import_react13.useCallback)((e) => {
+    openModal();
+    onClick && onClick(e);
+  }, [openModal, onClick]);
+  return <><WorkingButton_default onClick={_onClick} {...reactProps} style={buttonDefault(props.style)}>{children || <>Sign In</>}</WorkingButton_default></>;
+};
+var SignInButton_default = SignInButton;
+var buttonDefault = (providedStyles) => ({
+  lineHeight: "21px",
+  border: "none",
+  cursor: "pointer",
+  fontFamily: "inherit",
+  fontSize: "14px",
+  ...providedStyles || {}
+});
+
+// src/components/headless/HoverColorButton.tsx
+var import_react14 = require("react");
+var HoverColorButton = (props) => {
+  const { hoverBackgroundColor, hoverChildren, children, style, ...workingButtonProps } = props;
+  const [hover, setHover] = (0, import_react14.useState)(false);
+  const onMouseEnter = (0, import_react14.useCallback)(() => {
+    setHover(true);
+  }, []);
+  const onMouseLeave = (0, import_react14.useCallback)(() => {
+    setHover(false);
+  }, []);
+  return <WorkingButton_default
+    onMouseEnter={onMouseEnter}
+    onMouseLeave={onMouseLeave}
+    style={{
+      ...style,
+      backgroundColor: hover ? hoverBackgroundColor || primaryColor : void 0,
+      color: hover ? "white" : "black"
+    }}
+    {...workingButtonProps}
+  >{hover ? hoverChildren : children}</WorkingButton_default>;
+};
+var HoverColorButton_default = HoverColorButton;
+
+// src/components/styled/AddressWidget.tsx
+var import_react18 = require("react");
+
+// src/lib/truncateMiddle.ts
+var truncateMiddle = (text, length = 6) => text ? `${text.slice(0, length)}...${text.slice(length * -1)}` : "";
+var truncateMiddle_default = truncateMiddle;
+
+// src/components/svg/Sui.tsx
+var Sui = ({ width = 24, color = "#6EBCEE" }) => <svg
+  id="SuiSvg"
+  xmlns="http://www.w3.org/2000/svg"
+  width={width}
+  height={width * (40 / 28)}
+  viewBox="-1 0 28 40"
+  style={{ display: "block", verticalAlign: "middle" }}
+><path
+  d="M1.8611,33.0541a13.6477,13.6477,0,0,0,23.7778,0,13.89,13.89,0,0,0,0-13.8909L15.1824.8368a1.6444,1.6444,0,0,0-2.8648,0L1.8611,19.1632A13.89,13.89,0,0,0,1.8611,33.0541ZM10.8044,9.5555,13.0338,5.648a.8222.8222,0,0,1,1.4324,0L23.043,20.68a10.8426,10.8426,0,0,1,.8873,8.8828,9.4254,9.4254,0,0,0-.4388-1.4586c-1.1847-3.0254-3.8634-5.36-7.9633-6.9393-2.8187-1.0819-4.618-2.6731-5.3491-4.73C9.2375,13.7848,10.221,10.8942,10.8044,9.5555ZM7.0028,16.2184,4.457,20.68a10.8569,10.8569,0,0,0,0,10.8582,10.6776,10.6776,0,0,0,16.1566,2.935,7.5061,7.5061,0,0,0,.0667-5.2913c-.87-2.1858-2.9646-3.9308-6.2252-5.1876-3.6857-1.4147-6.08-3.6233-7.1157-6.5625A9.297,9.297,0,0,1,7.0028,16.2184Z"
+  style={{ fill: color, fillRule: "evenodd" }}
+/></svg>;
+var Sui_default = Sui;
+
+// src/components/styled/CopyWalletAddressButton.tsx
+var import_react15 = require("react");
+
+// src/components/styled/MenuButton.tsx
+var MenuButton = (props) => {
+  return <HoverColorButton_default
+    {...props}
+    style={button()}
+  />;
+};
+var MenuButton_default = MenuButton;
+var button = () => ({
+  width: "100%",
+  borderRadius: "12px",
+  textAlign: "left",
+  padding: "6px 12px",
+  display: "flex",
+  alignItems: "center",
+  gap: "6px",
+  border: "none",
+  fontFamily: "inherit",
+  cursor: "pointer"
+});
+
+// src/components/styled/CopyWalletAddressButton.tsx
+var CopyWalletAddressButton = (props) => {
+  const { externalContext, ...buttonProps } = props;
+  const { wallet } = externalContext?.wallet || useWallet_default();
+  const children = (0, import_react15.useCallback)((hover) => <>
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path
+      d="M15.6657 3.88789C15.3991 2.94272 14.5305 2.25 13.5 2.25H10.5C9.46954 2.25 8.60087 2.94272 8.33426 3.88789M15.6657 3.88789C15.7206 4.0825 15.75 4.28782 15.75 4.5V4.5C15.75 4.91421 15.4142 5.25 15 5.25H9C8.58579 5.25 8.25 4.91421 8.25 4.5V4.5C8.25 4.28782 8.27937 4.0825 8.33426 3.88789M15.6657 3.88789C16.3119 3.93668 16.9545 3.99828 17.5933 4.07241C18.6939 4.20014 19.5 5.149 19.5 6.25699V19.5C19.5 20.7426 18.4926 21.75 17.25 21.75H6.75C5.50736 21.75 4.5 20.7426 4.5 19.5V6.25699C4.5 5.149 5.30608 4.20014 6.40668 4.07241C7.04547 3.99828 7.68808 3.93668 8.33426 3.88789"
+      stroke={hover ? "white" : "black"}
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    /></svg>
+    {"Copy Wallet Address"}
+  </>, []);
+  const onClick = (0, import_react15.useCallback)((e) => {
+    const element = e.target;
+    const innerHTML = element.innerHTML;
+    element.innerHTML = "Copied!";
+    navigator.clipboard.writeText(wallet?.address || "");
+    setTimeout(() => {
+      element.innerHTML = innerHTML;
+    }, 1e3);
+  }, [wallet]);
+  return <MenuButton_default
+    {...buttonProps}
+    onClick={onClick}
+    hoverChildren={children(true)}
+  >{children(false)}</MenuButton_default>;
+};
+var CopyWalletAddressButton_default = CopyWalletAddressButton;
+
+// src/components/styled/WalletExplorerButton.tsx
+var import_react16 = require("react");
+var WalletExplorerButton = (props) => {
+  const children = (0, import_react16.useCallback)((hover) => <>
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path
+      d="M12 21C16.1926 21 19.7156 18.1332 20.7157 14.2529M12 21C7.80742 21 4.28442 18.1332 3.2843 14.2529M12 21C14.4853 21 16.5 16.9706 16.5 12C16.5 7.02944 14.4853 3 12 3M12 21C9.51472 21 7.5 16.9706 7.5 12C7.5 7.02944 9.51472 3 12 3M12 3C15.3652 3 18.299 4.84694 19.8431 7.58245M12 3C8.63481 3 5.70099 4.84694 4.15692 7.58245M19.8431 7.58245C17.7397 9.40039 14.9983 10.5 12 10.5C9.00172 10.5 6.26027 9.40039 4.15692 7.58245M19.8431 7.58245C20.5797 8.88743 21 10.3946 21 12C21 12.778 20.9013 13.5329 20.7157 14.2529M20.7157 14.2529C18.1334 15.6847 15.1619 16.5 12 16.5C8.8381 16.5 5.86662 15.6847 3.2843 14.2529M3.2843 14.2529C3.09871 13.5329 3 12.778 3 12C3 10.3946 3.42032 8.88743 4.15692 7.58245"
+      stroke={hover ? "white" : "black"}
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    /></svg>
+    {"Wallet Explorer"}
+  </>, []);
+  const onClick = (0, import_react16.useCallback)(() => {
+    window.open("https://ethoswallet.xyz/dashboard", "_blank");
+  }, []);
+  return <MenuButton_default
+    {...props}
+    onClick={onClick}
+    hoverChildren={children(true)}
+  >{children(false)}</MenuButton_default>;
+};
+var WalletExplorerButton_default = WalletExplorerButton;
+
+// src/components/styled/LogoutButton.tsx
+var import_react17 = require("react");
+var LogoutButton = (props) => {
+  const { externalContext, ...buttonProps } = props;
+  const { wallet } = externalContext?.wallet || useWallet_default();
+  const children = (0, import_react17.useCallback)((hover) => <>
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path
+      d="M13.5 21V20.25V21ZM7.5 21V21.75V21ZM5.25 18.75H6H5.25ZM5.25 5.25H4.5H5.25ZM7.5 3V2.25V3ZM13.5 3V3.75V3ZM15.75 5.25L15 5.25V5.25H15.75ZM15 9C15 9.41421 15.3358 9.75 15.75 9.75C16.1642 9.75 16.5 9.41421 16.5 9H15ZM16.5 15C16.5 14.5858 16.1642 14.25 15.75 14.25C15.3358 14.25 15 14.5858 15 15H16.5ZM15.75 18.75H16.5H15.75ZM18.2197 14.4697C17.9268 14.7626 17.9268 15.2374 18.2197 15.5303C18.5126 15.8232 18.9874 15.8232 19.2803 15.5303L18.2197 14.4697ZM21.75 12L22.2803 12.5303C22.5732 12.2374 22.5732 11.7626 22.2803 11.4697L21.75 12ZM19.2803 8.46967C18.9874 8.17678 18.5126 8.17678 18.2197 8.46967C17.9268 8.76256 17.9268 9.23744 18.2197 9.53033L19.2803 8.46967ZM9 11.25C8.58579 11.25 8.25 11.5858 8.25 12C8.25 12.4142 8.58579 12.75 9 12.75V11.25ZM13.5 20.25H7.5V21.75H13.5V20.25ZM6 18.75L6 5.25H4.5L4.5 18.75H6ZM7.5 3.75L13.5 3.75V2.25L7.5 2.25V3.75ZM15 5.25V9H16.5V5.25H15ZM15 15V18.75H16.5V15H15ZM6 5.25C6 4.42157 6.67157 3.75 7.5 3.75V2.25C5.84315 2.25 4.5 3.59315 4.5 5.25H6ZM7.5 20.25C6.67157 20.25 6 19.5784 6 18.75H4.5C4.5 20.4069 5.84315 21.75 7.5 21.75V20.25ZM13.5 21.75C15.1569 21.75 16.5 20.4069 16.5 18.75H15C15 19.5784 14.3284 20.25 13.5 20.25V21.75ZM13.5 3.75C14.3284 3.75 15 4.42157 15 5.25L16.5 5.25C16.5 3.59315 15.1569 2.25 13.5 2.25V3.75ZM19.2803 15.5303L22.2803 12.5303L21.2197 11.4697L18.2197 14.4697L19.2803 15.5303ZM22.2803 11.4697L19.2803 8.46967L18.2197 9.53033L21.2197 12.5303L22.2803 11.4697ZM21.75 11.25L9 11.25V12.75L21.75 12.75V11.25Z"
+      fill={hover ? "white" : "black"}
+    /></svg>
+    {"Log Out"}
+  </>, []);
+  return <MenuButton_default
+    {...buttonProps}
+    onClick={wallet?.disconnect}
+    hoverChildren={children(true)}
+  >{children(false)}</MenuButton_default>;
+};
+var LogoutButton_default = LogoutButton;
+
+// src/components/styled/AddressWidget.tsx
+var import_react19 = require("react");
+
+// src/enums/AddressWidgetButtons.ts
+var AddressWidgetButtons = /* @__PURE__ */ ((AddressWidgetButtons2) => {
+  AddressWidgetButtons2["CopyWalletAddress"] = "copy_wallet_address";
+  AddressWidgetButtons2["WalletExplorer"] = "wallet_explorer";
+  AddressWidgetButtons2["Logout"] = "logout";
+  return AddressWidgetButtons2;
+})(AddressWidgetButtons || {});
+
+// src/components/styled/AddressWidget.tsx
+var AddressWidget = ({
+  includeMenu = true,
+  buttonColor = primaryColor,
+  extraButtons = [],
+  excludeButtons = [],
+  externalContext
+}) => {
+  const { wallet } = externalContext?.wallet || useWallet_default();
+  const [showMenu, setShowMenu] = (0, import_react18.useState)(false);
+  (0, import_react19.useEffect)(() => {
+    if (!wallet) {
+      setShowMenu(false);
+    }
+  }, [wallet]);
+  const onMouseEnter = (0, import_react18.useCallback)(() => {
+    if (!wallet)
+      return;
+    setShowMenu(true);
+  }, [wallet]);
+  const onMouseLeave = (0, import_react18.useCallback)(() => {
+    if (!wallet)
+      return;
+    setShowMenu(false);
+  }, [wallet]);
+  return <div style={container()} onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
+    <div style={primary()}>
+      <div><Sui_default color="#222532" width={12} /></div>
+      {wallet ? <>
+        <div style={sui()}>
+          {formatBalance(wallet.contents?.suiBalance)}
+          {" "}
+          {"Sui"}
+        </div>
+        <div style={address()}>
+          {wallet.icon && <img
+            style={walletIcon()}
+            src={wallet.icon}
+          />}
+          {truncateMiddle_default(wallet.address)}
+        </div>
+      </> : <SignInButton_default style={signIn()} externalContext={externalContext} />}
+    </div>
+    {includeMenu && showMenu && <div style={menu()}>
+      {!excludeButtons.includes("copy_wallet_address" /* CopyWalletAddress */) && <CopyWalletAddressButton_default
+        externalContext={externalContext}
+        hoverBackgroundColor={buttonColor}
+      />}
+      {!excludeButtons.includes("wallet_explorer" /* WalletExplorer */) && <WalletExplorerButton_default
+        hoverBackgroundColor={buttonColor}
+      />}
+      {extraButtons}
+      {!excludeButtons.includes("logout" /* Logout */) && <LogoutButton_default
+        externalContext={externalContext}
+        hoverBackgroundColor={buttonColor}
+      />}
+    </div>}
+  </div>;
+};
+var AddressWidget_default = AddressWidget;
+var container = () => ({
+  position: "relative",
+  backgroundColor: "white",
+  padding: "6px 12px 6px 18px",
+  boxShadow: "1px 1px 3px 1px #dfdfe0",
+  borderRadius: "18px",
+  fontSize: "14px",
+  color: "black"
+});
+var primary = () => ({
+  display: "flex",
+  justifyContent: "center",
+  alignItems: "center",
+  gap: "12px"
+});
+var sui = () => ({
+  whiteSpace: "nowrap"
+});
+var address = () => ({
+  borderRadius: "30px",
+  backgroundColor: "#f2f1f0",
+  padding: "6px 12px",
+  display: "flex",
+  alignItems: "center",
+  gap: "6px"
+});
+var menu = () => ({
+  display: "flex",
+  flexDirection: "column",
+  gap: "6px",
+  padding: "12px 18px",
+  position: "absolute",
+  bottom: 0,
+  left: "12px",
+  right: "12px",
+  transform: "translateY(100%)",
+  boxShadow: "1px 1px 3px 1px #dfdfe0",
+  borderBottomLeftRadius: "18px",
+  borderBottomRightRadius: "18px",
+  backgroundColor: "white",
+  zIndex: "99"
+});
+var signIn = () => ({
+  padding: "0 12px 0 0",
+  background: "none",
+  whiteSpace: "nowrap"
+});
+var walletIcon = () => ({
+  width: "20px",
+  height: "20px"
+});
+
+// src/lib/logout.ts
+var logout = async (signer, fromWallet = false) => {
+  log_default("logout", `-- Wallet ${fromWallet} --`, `-- Is Extension: ${signer?.type} --`, `-- Disconnect: ${!!signer?.disconnect} --`, "signer", signer);
+  if (signer.type === "extension" || !fromWallet) {
+    await signer.disconnect();
+  } else {
+    await signer.logout();
+  }
+};
+var logout_default = logout;
+
+// src/lib/preapprove.ts
+var preapprove = async ({ signer, preapproval }) => {
+  return signer.requestPreapproval(preapproval);
+};
+var preapprove_default = preapprove;
+
+// src/lib/sign.ts
+var sign = async ({ signer, message }) => {
+  return signer.sign({ message });
+};
+var sign_default = sign;
+
+// src/lib/transact.ts
+var transact = async ({
+  signer,
+  transactionInput
+}) => {
+  log_default("transact", "Starting transaction", signer, transactionInput);
+  return signer.signAndExecuteTransactionBlock(transactionInput);
+};
+var transact_default = transact;
+
+// src/lib/hideWallet.ts
+var hideWallet = (signer) => {
+  if (signer.type === "extension" /* Extension */)
+    return;
+  getIframe_default(false);
+};
+var hideWallet_default = hideWallet;
+
+// src/lib/showWallet.ts
+var showWallet = (signer) => {
+  if (signer.type === "extension" /* Extension */)
+    return;
+  getIframe_default(true);
+};
+var showWallet_default = showWallet;
+
+// src/lib/dripSui.ts
+var import_sui4 = require("@mysten/sui.js");
+var dripSui = async ({ address: address2, network, faucet }) => {
+  const connection = new import_sui4.Connection({ fullnode: network ?? DEFAULT_NETWORK, faucet: `${faucet ?? DEFAULT_FAUCET}gas` });
+  const provider = new import_sui4.JsonRpcProvider(connection);
+  return provider.requestSuiFromFaucet(address2);
+};
+var dripSui_default = dripSui;
+
+// src/lib/nameService.ts
+var import_lodash2 = __toESM(require("lodash"), 1);
+var import_sui5 = require("@mysten/sui.js");
+var PACKAGE_ADDRESS = "0xe7ed73e4c2c1b38729155bf5c44dc4496a9edd2f";
+var REGISTRY_ADDRESS = "0xa378adb13792599e8eb8c7e4f2e938863921e4f4";
+var SENDER = "0x0000000000000000000000000000000000000002";
+var DEV_INSPECT_RESULT_PATH_0 = "results.Ok[0][1].returnValues[0][0]";
+var DEV_INSPECT_RESULT_PATH_1 = "results.Ok[0][1].returnValues[1][0]";
+var toHexString = (byteArray) => byteArray?.length > 0 ? Array.from(byteArray, (byte) => ("0" + (byte & 255).toString(16)).slice(-2)).join("") : "";
+var toString = (byteArray) => byteArray?.length > 0 ? new TextDecoder().decode(Buffer.from(byteArray.slice(1)).buffer) : "";
+var trimAddress = (address2) => String(address2?.match(/0x0{0,}([\w\d]+)/)?.[1]);
+var toFullAddress = (trimmedAddress) => trimmedAddress ? `0x${trimmedAddress.padStart(40, "0")}` : "";
+var getSuiName = async (address2, network, sender = SENDER) => {
+  const connection = new import_sui5.Connection({ fullnode: network || DEFAULT_NETWORK });
+  const suiProvider = new import_sui5.JsonRpcProvider(connection);
+  try {
+    const registryTx = new import_sui5.TransactionBlock();
+    registryTx.add(
+      import_sui5.TransactionBlock.Transactions.MoveCall({
+        target: `${PACKAGE_ADDRESS}::base_registry::get_record_by_key`,
+        arguments: [
+          registryTx.object(REGISTRY_ADDRESS),
+          registryTx.pure(`${trimAddress(address2)}.addr.reverse`)
+        ]
+      })
+    );
+    const resolverBytes = import_lodash2.default.get(
+      await suiProvider.devInspectTransactionBlock({
+        transactionBlock: registryTx,
+        sender
+      }),
+      DEV_INSPECT_RESULT_PATH_1
+    );
+    if (!resolverBytes)
+      return address2;
+    const resolver = toFullAddress(toHexString(resolverBytes));
+    const resolverTx = new import_sui5.TransactionBlock();
+    resolverTx.add(
+      import_sui5.TransactionBlock.Transactions.MoveCall({
+        target: `${PACKAGE_ADDRESS}::resolver::name`,
+        arguments: [
+          registryTx.object(resolver),
+          registryTx.pure(address2)
+        ]
+      })
+    );
+    const resolverResponse = await suiProvider.devInspectTransactionBlock({
+      transactionBlock: resolverTx,
+      sender
+    });
+    const nameByteArray = import_lodash2.default.get(resolverResponse, DEV_INSPECT_RESULT_PATH_0);
+    if (!nameByteArray)
+      return address2;
+    const name = toString(nameByteArray);
+    return name;
+  } catch (e) {
+    console.log("Error retreiving SuiNS Name", e);
+    return address2;
+  }
+};
+var getSuiAddress = async (domain, network, sender = SENDER) => {
+  const connection = new import_sui5.Connection({ fullnode: network || DEFAULT_NETWORK });
+  const suiProvider = new import_sui5.JsonRpcProvider(connection);
+  try {
+    const registryTx = new import_sui5.TransactionBlock();
+    registryTx.add(
+      import_sui5.TransactionBlock.Transactions.MoveCall({
+        target: `${PACKAGE_ADDRESS}::base_registry::get_record_by_key`,
+        arguments: [
+          registryTx.object(REGISTRY_ADDRESS),
+          registryTx.pure(domain)
+        ]
+      })
+    );
+    const resolverResponse = await suiProvider.devInspectTransactionBlock({
+      transactionBlock: registryTx,
+      sender
+    });
+    const resolverBytes = import_lodash2.default.get(resolverResponse, DEV_INSPECT_RESULT_PATH_1);
+    if (!resolverBytes)
+      return domain;
+    const resolver = toFullAddress(toHexString(resolverBytes));
+    const resolverTx = new import_sui5.TransactionBlock();
+    resolverTx.add(
+      import_sui5.TransactionBlock.Transactions.MoveCall({
+        target: `${PACKAGE_ADDRESS}::resolver::addr`,
+        arguments: [
+          registryTx.object(resolver),
+          registryTx.pure(domain)
+        ]
+      })
+    );
+    const resolverResponse2 = await suiProvider.devInspectTransactionBlock({
+      transactionBlock: resolverTx,
+      sender
+    });
+    const addr = import_lodash2.default.get(resolverResponse2, DEV_INSPECT_RESULT_PATH_0);
+    if (!addr)
+      return domain;
+    return toFullAddress(toHexString(addr));
+  } catch (e) {
+    console.log("Error retrieving address from SuiNS name", e);
+    return domain;
+  }
+};
+
+// src/hooks/useProviderAndSigner.ts
+var import_react20 = require("react");
+var useProviderAndSigner = () => {
+  const { providerAndSigner } = (0, import_react20.useContext)(ConnectContext_default);
+  return providerAndSigner || { provider: null, signer: null };
+};
+var useProviderAndSigner_default = useProviderAndSigner;
+
+// src/hooks/useAddress.ts
+var useAddress = () => {
+  const { signer } = useProviderAndSigner_default();
+  return signer?.currentAccount?.address;
+};
+var useAddress_default = useAddress;
+
+// src/hooks/useContents.ts
+var import_react21 = require("react");
+var useContents = () => {
+  const contents = (0, import_react21.useContext)(ConnectContext_default).wallet?.wallet?.contents;
+  return contents;
+};
+var useContents_default = useContents;
+
+// src/components/DetachedEthosConnectProvider.tsx
+var DetachedEthosConnectProvider = ({ context, connectMessage, dappName, dappIcon, children }) => {
+  return <>
+    {children}
+    <SignInModal_default
+      isOpen={context.modal.isModalOpen}
+      hideEmailSignIn={context.ethosConfiguration?.hideEmailSignIn || false}
+      hideWalletSignIn={context.ethosConfiguration?.hideWalletSignIn || false}
+      connectMessage={connectMessage}
+      dappName={dappName}
+      dappIcon={dappIcon}
+      externalContext={context}
+    />
+  </>;
+};
+var DetachedEthosConnectProvider_default = DetachedEthosConnectProvider;
+
+// src/index.ts
+var components = {
+  AddressWidget: AddressWidget_default,
+  MenuButton: MenuButton_default,
+  headless: {
+    HoverColorButton: HoverColorButton_default
+  }
+};
+var enums = {
+  AddressWidgetButtons
+};
+var ethos = {
+  login: login_default,
+  logout: logout_default,
+  sign: sign_default,
+  transact: transact_default,
+  preapprove: preapprove_default,
+  showWallet: showWallet_default,
+  hideWallet: hideWallet_default,
+  showSignInModal,
+  hideSignInModal,
+  useProviderAndSigner: useProviderAndSigner_default,
+  useAddress: useAddress_default,
+  useContents: useContents_default,
+  useWallet: useWallet_default,
+  useContext: useContext_default,
+  getWalletContents: getWalletContents_default,
+  dripSui: dripSui_default,
+  getSuiName,
+  getSuiAddress,
+  formatBalance,
+  truncateMiddle: truncateMiddle_default,
+  ipfsConversion,
+  components,
+  enums
+};
+// Annotate the CommonJS export names for ESM import in node:
+0 && (module.exports = {
+  Chain,
+  DetachedEthosConnectProvider,
+  EthosConnectProvider,
+  EthosConnectStatus,
+  IntentScope,
+  SignInButton,
+  TransactionBlock,
+  ethos,
+  verifyMessage
+});

--- a/tsup/index.d.ts
+++ b/tsup/index.d.ts
@@ -1,0 +1,639 @@
+import { ButtonHTMLAttributes, ReactNode } from 'react';
+import BigNumber from 'bignumber.js';
+import * as _mysten_sui_js from '@mysten/sui.js';
+import { ObjectId, TransactionBlock, SuiAddress, SuiTransactionBlockResponse, SignedTransaction, JsonRpcProvider } from '@mysten/sui.js';
+export { IntentScope, TransactionBlock, verifyMessage } from '@mysten/sui.js';
+import { WalletAdapter } from '@mysten/wallet-adapter-base';
+import { IdentifierString, WalletAccount, SuiSignAndExecuteTransactionBlockInput, SuiSignMessageOutput } from '@mysten/wallet-standard';
+export { WalletAccount } from '@mysten/wallet-standard';
+
+interface WorkingButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+    isWorking?: boolean;
+    workingComponent?: ReactNode;
+}
+
+interface HoverColorButtonProps extends WorkingButtonProps {
+    hoverBackgroundColor?: string;
+    hoverChildren: ReactNode;
+}
+
+declare enum AddressWidgetButtons {
+    CopyWalletAddress = "copy_wallet_address",
+    WalletExplorer = "wallet_explorer",
+    Logout = "logout"
+}
+
+interface AddressWidgetProps {
+    includeMenu?: boolean;
+    buttonColor?: string;
+    extraButtons?: ReactNode[];
+    excludeButtons?: AddressWidgetButtons[];
+    externalContext?: any;
+}
+
+interface SuiNFTCollection {
+    name: string;
+    type: string;
+}
+interface SuiNFT {
+    chain: string;
+    type: string;
+    package: string;
+    module: string;
+    address: string;
+    objectId: string;
+    name?: string;
+    description?: string;
+    imageUri?: string;
+    link?: string;
+    creator?: string;
+    projectUrl?: string;
+    display?: Record<string, string>;
+    extraFields?: Record<string, string>;
+    collection?: SuiNFTCollection;
+    links?: Record<string, string>;
+}
+interface Coin {
+    type: string;
+    objectId: string;
+    balance: BigNumber;
+    digest: string;
+    version: number;
+}
+interface Token {
+    balance: number;
+    coins: Coin[];
+}
+interface WalletContents {
+    suiBalance: BigNumber;
+    tokens: {
+        [key: string]: Token;
+    };
+    nfts: SuiNFT[];
+    objects: any[];
+}
+
+declare type GetWalletContentsArgs = {
+    address: string;
+    network: string;
+    existingContents?: WalletContents;
+};
+
+interface Preapproval {
+    target: `${string}::${string}::${string}`;
+    chain: IdentifierString;
+    address?: string;
+    objectId: ObjectId;
+    description: string;
+    totalGasLimit: number;
+    perTransactionGasLimit: number;
+    maxTransactionCount: number;
+}
+
+declare type EthosSignMessageInput = {
+    message: string | Uint8Array;
+    account?: WalletAccount;
+    chain?: string;
+};
+
+interface EthosSignTransactionBlockInput {
+    transactionBlock: TransactionBlock;
+    account?: WalletAccount;
+    chain?: IdentifierString;
+}
+
+declare type EthosSignAndExecuteTransactionBlockInput = {
+    transactionBlock: TransactionBlock;
+    options?: SuiSignAndExecuteTransactionBlockInput['options'];
+    requestType?: SuiSignAndExecuteTransactionBlockInput['requestType'];
+    account?: WalletAccount;
+    chain?: IdentifierString;
+};
+
+declare enum SignerType {
+    Extension = "extension",
+    Hosted = "hosted"
+}
+interface Signer {
+    type: SignerType;
+    name?: string;
+    icon?: string;
+    getAddress: () => Promise<SuiAddress | null>;
+    accounts: readonly WalletAccount[];
+    currentAccount: WalletAccount | null;
+    signAndExecuteTransactionBlock: (input: EthosSignAndExecuteTransactionBlockInput) => Promise<SuiTransactionBlockResponse>;
+    signTransactionBlock: (input: EthosSignTransactionBlockInput) => Promise<SignedTransaction>;
+    requestPreapproval: (preApproval: Preapproval) => Promise<boolean>;
+    signMessage: (input: EthosSignMessageInput) => Promise<SuiSignMessageOutput>;
+    disconnect: () => void;
+}
+interface ExtensionSigner extends Signer {
+    type: SignerType.Extension;
+}
+interface HostedSigner extends Signer {
+    type: SignerType.Hosted;
+    email?: string;
+    logout: () => void;
+}
+
+interface Wallet extends Signer {
+    address: SuiAddress;
+    contents?: WalletContents;
+}
+
+declare enum EthosConnectStatus {
+    Loading = "loading",
+    NoConnection = "no_connection",
+    Connected = "connected"
+}
+
+declare type WalletContextContents = {
+    wallets?: WalletAdapter[];
+    selectWallet?: ((walletName: string) => void);
+    status: EthosConnectStatus;
+    provider: JsonRpcProvider | null;
+    wallet?: Wallet;
+    altAccount?: WalletAccount;
+    setAltAccount: (_account: WalletAccount) => void;
+};
+
+interface ModalContextContents {
+    isModalOpen: boolean;
+    openModal: () => void;
+    closeModal: () => void;
+}
+
+declare type ProviderAndSigner = {
+    provider: JsonRpcProvider | null;
+    signer: ExtensionSigner | HostedSigner | null;
+};
+
+declare enum Chain {
+    SUI_DEVNET = "sui:devnet",
+    SUI_TESTNET = "sui:testnet",
+    SUI_CUSTOM = "sui:custom"
+}
+
+interface EthosConfiguration {
+    apiKey?: string;
+    walletAppUrl?: string;
+    chain?: Chain;
+    network?: string;
+    hideEmailSignIn?: boolean;
+    hideWalletSignIn?: boolean;
+    preferredWallets?: string[];
+    redirectTo?: string;
+    disableAutoConnect?: boolean;
+}
+
+interface ConnectContextContents {
+    wallet?: WalletContextContents;
+    modal?: ModalContextContents;
+    providerAndSigner?: ProviderAndSigner;
+    ethosConfiguration?: EthosConfiguration;
+    init: (configuration: EthosConfiguration) => void;
+}
+
+interface UseContextArgs {
+    configuration?: EthosConfiguration;
+    onWalletConnected?: (providerAndSigner: ProviderAndSigner) => void;
+}
+
+declare type PreapprovalArgs = {
+    signer: any;
+    preapproval: Preapproval;
+};
+
+declare type User = {
+    email: string;
+    wallet: string;
+};
+
+declare type loginArgs = {
+    email?: string;
+    provider?: string;
+    apiKey?: string;
+};
+
+interface EthosConnectProviderProps {
+    ethosConfiguration?: EthosConfiguration;
+    onWalletConnected?: ({ provider, signer }: ProviderAndSigner) => void;
+    connectMessage?: string | ReactNode;
+    dappName?: string;
+    dappIcon?: string | ReactNode;
+    children: ReactNode;
+}
+declare const EthosConnectProvider: ({ ethosConfiguration, onWalletConnected, connectMessage, dappName, dappIcon, children }: EthosConnectProviderProps) => JSX.Element;
+
+interface SignInButtonProps extends WorkingButtonProps {
+    onLoaded?: () => void;
+    externalContext?: any;
+}
+declare const SignInButton: (props: SignInButtonProps) => JSX.Element;
+
+declare global {
+    interface Window {
+        ethosInternal: any;
+    }
+}
+
+declare function showSignInModal(): void;
+declare function hideSignInModal(): void;
+
+interface DetachedEthosConnectProviderProps {
+    context: any;
+    connectMessage?: string | ReactNode;
+    dappName?: string;
+    dappIcon?: string | ReactNode;
+    children: ReactNode;
+}
+declare const DetachedEthosConnectProvider: ({ context, connectMessage, dappName, dappIcon, children }: DetachedEthosConnectProviderProps) => JSX.Element;
+
+declare const ethos: {
+    login: ({ email, provider, apiKey }: loginArgs) => Promise<User | null | undefined>;
+    logout: (signer: ExtensionSigner | HostedSigner, fromWallet?: boolean) => Promise<void>;
+    sign: ({ signer, message }: {
+        signer?: any;
+        message: string | Uint8Array;
+    }) => Promise<any>;
+    transact: ({ signer, transactionInput }: {
+        signer: ExtensionSigner | HostedSigner;
+        transactionInput: EthosSignAndExecuteTransactionBlockInput;
+    }) => Promise<{
+        digest: string;
+        timestampMs?: string | undefined;
+        transaction?: {
+            data: {
+                sender: string;
+                messageVersion: "v1";
+                transaction: {
+                    epoch: string;
+                    storage_charge: string;
+                    computation_charge: string;
+                    storage_rebate: string;
+                    kind: "ChangeEpoch";
+                    epoch_start_timestamp_ms?: string | undefined;
+                } | {
+                    epoch: string;
+                    round: string;
+                    commit_timestamp_ms: string;
+                    kind: "ConsensusCommitPrologue";
+                } | {
+                    objects: string[];
+                    kind: "Genesis";
+                } | {
+                    transactions: ({
+                        MoveCall: {
+                            function: string;
+                            package: string;
+                            module: string;
+                            arguments?: ("GasCoin" | {
+                                Input: number;
+                            } | {
+                                Result: number;
+                            } | {
+                                NestedResult: [number, number];
+                            })[] | undefined;
+                            type_arguments?: string[] | undefined;
+                        };
+                    } | {
+                        TransferObjects: [("GasCoin" | {
+                            Input: number;
+                        } | {
+                            Result: number;
+                        } | {
+                            NestedResult: [number, number];
+                        })[], "GasCoin" | {
+                            Input: number;
+                        } | {
+                            Result: number;
+                        } | {
+                            NestedResult: [number, number];
+                        }];
+                    } | {
+                        SplitCoins: ["GasCoin" | {
+                            Input: number;
+                        } | {
+                            Result: number;
+                        } | {
+                            NestedResult: [number, number];
+                        }, ("GasCoin" | {
+                            Input: number;
+                        } | {
+                            Result: number;
+                        } | {
+                            NestedResult: [number, number];
+                        })[]];
+                    } | {
+                        MergeCoins: ["GasCoin" | {
+                            Input: number;
+                        } | {
+                            Result: number;
+                        } | {
+                            NestedResult: [number, number];
+                        }, ("GasCoin" | {
+                            Input: number;
+                        } | {
+                            Result: number;
+                        } | {
+                            NestedResult: [number, number];
+                        })[]];
+                    } | {
+                        Publish: [{
+                            disassembled: Record<string, string>;
+                        }, string[]];
+                    } | {
+                        Upgrade: [{
+                            disassembled: Record<string, string>;
+                        }, string[], string, "GasCoin" | {
+                            Input: number;
+                        } | {
+                            Result: number;
+                        } | {
+                            NestedResult: [number, number];
+                        }];
+                    } | {
+                        MakeMoveVec: [string | null, ("GasCoin" | {
+                            Input: number;
+                        } | {
+                            Result: number;
+                        } | {
+                            NestedResult: [number, number];
+                        })[]];
+                    })[];
+                    inputs: ({
+                        type: "pure";
+                        value: _mysten_sui_js.SuiJsonValue;
+                        valueType?: string | undefined;
+                    } | {
+                        type: "object";
+                        objectType: "immOrOwnedObject";
+                        objectId: string;
+                        version: string;
+                        digest: string;
+                    } | {
+                        type: "object";
+                        objectType: "sharedObject";
+                        objectId: string;
+                        initialSharedVersion: string;
+                        mutable: boolean;
+                    })[];
+                    kind: "ProgrammableTransaction";
+                };
+                gasData: {
+                    payment: {
+                        objectId: string;
+                        version: string | number;
+                        digest: string;
+                    }[];
+                    owner: string;
+                    price: string;
+                    budget: string;
+                };
+            };
+            txSignatures: string[];
+        } | undefined;
+        effects?: {
+            messageVersion: "v1";
+            status: {
+                status: "success" | "failure";
+                error?: string | undefined;
+            };
+            executedEpoch: string;
+            gasUsed: {
+                computationCost: string;
+                storageCost: string;
+                storageRebate: string;
+                nonRefundableStorageFee: string;
+            };
+            transactionDigest: string;
+            gasObject: {
+                owner: "Immutable" | {
+                    AddressOwner: string;
+                } | {
+                    ObjectOwner: string;
+                } | {
+                    Shared: {
+                        initial_shared_version: number;
+                    };
+                };
+                reference: {
+                    objectId: string;
+                    version: string | number;
+                    digest: string;
+                };
+            };
+            modifiedAtVersions?: {
+                objectId: string;
+                sequenceNumber: string;
+            }[] | undefined;
+            sharedObjects?: {
+                objectId: string;
+                version: string | number;
+                digest: string;
+            }[] | undefined;
+            created?: {
+                owner: "Immutable" | {
+                    AddressOwner: string;
+                } | {
+                    ObjectOwner: string;
+                } | {
+                    Shared: {
+                        initial_shared_version: number;
+                    };
+                };
+                reference: {
+                    objectId: string;
+                    version: string | number;
+                    digest: string;
+                };
+            }[] | undefined;
+            mutated?: {
+                owner: "Immutable" | {
+                    AddressOwner: string;
+                } | {
+                    ObjectOwner: string;
+                } | {
+                    Shared: {
+                        initial_shared_version: number;
+                    };
+                };
+                reference: {
+                    objectId: string;
+                    version: string | number;
+                    digest: string;
+                };
+            }[] | undefined;
+            unwrapped?: {
+                owner: "Immutable" | {
+                    AddressOwner: string;
+                } | {
+                    ObjectOwner: string;
+                } | {
+                    Shared: {
+                        initial_shared_version: number;
+                    };
+                };
+                reference: {
+                    objectId: string;
+                    version: string | number;
+                    digest: string;
+                };
+            }[] | undefined;
+            deleted?: {
+                objectId: string;
+                version: string | number;
+                digest: string;
+            }[] | undefined;
+            unwrapped_then_deleted?: {
+                objectId: string;
+                version: string | number;
+                digest: string;
+            }[] | undefined;
+            wrapped?: {
+                objectId: string;
+                version: string | number;
+                digest: string;
+            }[] | undefined;
+            eventsDigest?: string | undefined;
+            dependencies?: string[] | undefined;
+        } | undefined;
+        events?: {
+            id: {
+                txDigest: string;
+                eventSeq: string;
+            };
+            packageId: string;
+            transactionModule: string;
+            sender: string;
+            type: string;
+            parsedJson?: Record<string, any> | undefined;
+            bcs?: string | undefined;
+            timestampMs?: string | undefined;
+        }[] | undefined;
+        checkpoint?: string | undefined;
+        confirmedLocalExecution?: boolean | undefined;
+        objectChanges?: ({
+            packageId: string;
+            type: "published";
+            version: string;
+            digest: string;
+            modules: string[];
+        } | {
+            sender: string;
+            type: "transferred";
+            objectType: string;
+            objectId: string;
+            version: string;
+            digest: string;
+            recipient: "Immutable" | {
+                AddressOwner: string;
+            } | {
+                ObjectOwner: string;
+            } | {
+                Shared: {
+                    initial_shared_version: number;
+                };
+            };
+        } | {
+            sender: string;
+            type: "mutated";
+            objectType: string;
+            objectId: string;
+            version: string;
+            digest: string;
+            owner: "Immutable" | {
+                AddressOwner: string;
+            } | {
+                ObjectOwner: string;
+            } | {
+                Shared: {
+                    initial_shared_version: number;
+                };
+            };
+            previousVersion: string;
+        } | {
+            sender: string;
+            type: "deleted";
+            objectType: string;
+            objectId: string;
+            version: string;
+        } | {
+            sender: string;
+            type: "wrapped";
+            objectType: string;
+            objectId: string;
+            version: string;
+        } | {
+            sender: string;
+            type: "created";
+            objectType: string;
+            objectId: string;
+            version: string;
+            digest: string;
+            owner: "Immutable" | {
+                AddressOwner: string;
+            } | {
+                ObjectOwner: string;
+            } | {
+                Shared: {
+                    initial_shared_version: number;
+                };
+            };
+        })[] | undefined;
+        balanceChanges?: {
+            owner: "Immutable" | {
+                AddressOwner: string;
+            } | {
+                ObjectOwner: string;
+            } | {
+                Shared: {
+                    initial_shared_version: number;
+                };
+            };
+            coinType: string;
+            amount: string;
+        }[] | undefined;
+        errors?: string[] | undefined;
+    }>;
+    preapprove: ({ signer, preapproval }: PreapprovalArgs) => Promise<any>;
+    showWallet: (signer: Signer) => void;
+    hideWallet: (signer: Signer) => void;
+    showSignInModal: typeof showSignInModal;
+    hideSignInModal: typeof hideSignInModal;
+    useProviderAndSigner: () => ProviderAndSigner;
+    useAddress: () => string | undefined;
+    useContents: () => WalletContents | undefined;
+    useWallet: () => WalletContextContents;
+    useContext: ({ configuration, onWalletConnected }: UseContextArgs) => ConnectContextContents;
+    getWalletContents: ({ address, network, existingContents }: GetWalletContentsArgs) => Promise<WalletContents | null>;
+    dripSui: ({ address, network, faucet }: {
+        address: string;
+        network?: string | undefined;
+        faucet?: string | undefined;
+    }) => Promise<{
+        error: string | null;
+        transferredGasObjects: {
+            id: string;
+            amount: number;
+            transferTxDigest: string;
+        }[];
+    }>;
+    getSuiName: (address: string, network: string, sender?: string) => Promise<string>;
+    getSuiAddress: (domain: string, network: string, sender?: string) => Promise<string>;
+    formatBalance: (balance?: string | number | bigint | undefined, decimals?: number) => string;
+    truncateMiddle: (text: string, length?: number) => string;
+    ipfsConversion: (src?: string | undefined) => string;
+    components: {
+        AddressWidget: ({ includeMenu, buttonColor, extraButtons, excludeButtons, externalContext }: AddressWidgetProps) => JSX.Element;
+        MenuButton: (props: HoverColorButtonProps) => JSX.Element;
+        headless: {
+            HoverColorButton: (props: HoverColorButtonProps) => JSX.Element;
+        };
+    };
+    enums: {
+        AddressWidgetButtons: typeof AddressWidgetButtons;
+    };
+};
+
+export { Chain, DetachedEthosConnectProvider, EthosConnectProvider, EthosConnectStatus, ProviderAndSigner, SignInButton, Signer, SuiNFT, Token, Wallet, WalletContents, ethos };

--- a/tsup/index.js
+++ b/tsup/index.js
@@ -1,0 +1,2500 @@
+// src/index.ts
+import { TransactionBlock as TransactionBlock2, verifyMessage, IntentScope } from "@mysten/sui.js";
+
+// src/components/styled/SignInModal.tsx
+import { useCallback as useCallback3, useEffect as useEffect3, useMemo as useMemo2, useState as useState3 } from "react";
+
+// src/components/svg/Loader.tsx
+var Loader = ({ width = 100, color = "#333" }) => <svg
+  version="1.1"
+  id="L4"
+  xmlns="http://www.w3.org/2000/svg"
+  x="0px"
+  y="0px"
+  viewBox="0 0 54 20"
+  width={width}
+  height={width * (20 / 54)}
+  enableBackground="new 0 0 0 0"
+>
+  <circle fill={color} stroke="none" cx="6" cy="10" r="6"><animate
+    attributeName="opacity"
+    dur="1.5s"
+    values="0;1;0"
+    repeatCount="indefinite"
+    begin="0.1"
+  /></circle>
+  <circle fill={color} stroke="none" cx="26" cy="10" r="6"><animate
+    attributeName="opacity"
+    dur="1.5s"
+    values="0;1;0"
+    repeatCount="indefinite"
+    begin="0.5"
+  /></circle>
+  <circle fill={color} stroke="none" cx="46" cy="10" r="6"><animate
+    attributeName="opacity"
+    dur="1.5s"
+    values="0;1;0"
+    repeatCount="indefinite"
+    begin="1.0"
+  /></circle>
+</svg>;
+var Loader_default = Loader;
+
+// src/components/svg/WalletsIcon.tsx
+var WalletsIcon = ({ width = 32 }) => <img src={dataUri} width={width} height={width} />;
+var WalletsIcon_default = WalletsIcon;
+var dataUri = `data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAAeGVYSWZNTQAqAAAACAAFARIAAwAAAAEAAQAAARoABQAAAAEAAABKARsABQAAAAEAAABSASgAAwAAAAEAAgAAh2kABAAAAAEAAABaAAAAAAAAAEgAAAABAAAASAAAAAEAAqACAAQAAAABAAAAIKADAAQAAAABAAAAIAAAAAAQdIdCAAAACXBIWXMAAAsTAAALEwEAmpwYAAACZmlUWHRYTUw6Y29tLmFkb2JlLnhtcAAAAAAAPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyIgeDp4bXB0az0iWE1QIENvcmUgNS40LjAiPgogICA8cmRmOlJERiB4bWxuczpyZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiPgogICAgICA8cmRmOkRlc2NyaXB0aW9uIHJkZjphYm91dD0iIgogICAgICAgICAgICB4bWxuczp0aWZmPSJodHRwOi8vbnMuYWRvYmUuY29tL3RpZmYvMS4wLyIKICAgICAgICAgICAgeG1sbnM6ZXhpZj0iaHR0cDovL25zLmFkb2JlLmNvbS9leGlmLzEuMC8iPgogICAgICAgICA8dGlmZjpPcmllbnRhdGlvbj4xPC90aWZmOk9yaWVudGF0aW9uPgogICAgICAgICA8dGlmZjpSZXNvbHV0aW9uVW5pdD4yPC90aWZmOlJlc29sdXRpb25Vbml0PgogICAgICAgICA8ZXhpZjpDb2xvclNwYWNlPjE8L2V4aWY6Q29sb3JTcGFjZT4KICAgICAgICAgPGV4aWY6UGl4ZWxYRGltZW5zaW9uPjU2PC9leGlmOlBpeGVsWERpbWVuc2lvbj4KICAgICAgICAgPGV4aWY6UGl4ZWxZRGltZW5zaW9uPjU2PC9leGlmOlBpeGVsWURpbWVuc2lvbj4KICAgICAgPC9yZGY6RGVzY3JpcHRpb24+CiAgIDwvcmRmOlJERj4KPC94OnhtcG1ldGE+CiB3yYcAAAgwSURBVFgJrZddiJ1HGcefmXfe9z3n7G42yTYamy9sklZT0XilAeuFdwXxQrD4gVKwF6IXohdS8CYXJWJFwQvprXhTaOhVFakFjbGWioqItKYXprVda0OaNNnd8/F+jr//nN1k16RCwLM778w8M2f+//k/zzzzHme3+Zw+/Zuw+94TK7mvDucxHCws3h2ie19u9p68d3vy3kaFuYG3diH4We/9dJaF2SzLKG58xWfTyz4b/zvPJqsun6zW9eS1j2785ap76Gz333Buu+H0M2+OwrQ5Wzj/YBbNhWiWR2eAG+CxiJ6+WeijK5KNMWssy6YGCdWR4pwbWwgTbGNsam9QxtH5jSfqS6vfuv+hs/UW7g0C33l69WARu38GMx/Mxaw3l5uAXQypPScjQihgxSY51cE3mwQmAApY9Rx8Xs8JZNm6y/z6uCjHRw5+7GdXRMLr8bmnYtZZe6Hx0TdQalUYaVy02qKTjfpGUb/xLjbeotpdn1uMZey60vp+sFlKm/dxYJRddR77mC+0bfZyjKcTNhs221e89khjbhTZTc+DDbrAwmgWIx0sUMGgj6MbkQE3yOY8hTnWFy74HlB1OnOuTaXvW8BZ3eUOEtE5EQn73njxwleY+FMRcJ23M1BL6wQWjJDQ4n3sXX+TiAMSQoBDTNj84SAm43XYQqSkyZS+x9IB1lJvEaghUtOvWB8Sff6DRODrT720UFm717uMfTrWnxPp5VuBg8KSLnrUoEMcYmQO+8eDPMRHIokWoduVLkge1yXwmwTkkgqCBTVh7sPKhec/sxTqpeye2MKSBWPEsS5jB2wGcJFgYzBXu8MGCW1Wam0S2VJLdqbyBUK4G9CUC+SKDkAFacPUGn2IpjgDo3QL+cL7Q9O3xwnF6NmlAc6IdgtgFg/sLu3LJ1fcgeVCS+uTMObN2z53jM/GtV144YJV641IMFZBpKZdooACM9wXWl8fz5JgWfSA9z7AFAlQ5Esn73YXrkztr29xtFAjFThkYCM2tUs29jzvy0ZRX8d3tOjcoRNH7JUX1llPKtSclArwASoUwJTHyTHN0R4JCDnAgQDcm1c02PdffD1WtUAUIT7mSB9UEwvzXOBSPiixFXBWTijx2QAxKW5A0AyH5Jx+gd12gDeAb5EYupDNjobeNUcURYouoOZuYEGcZSujwj1y6qAd2lVK7y15t+rtPridzaYbnf3t3FWbrin4dCIatK6oZxAiX8TyMATa/TEpAAGCjJ0TTiLU2Vc/csxevrJmf740D3+FmcY0C0QiZu4WuUJp+0ZNWxlz12Kwwx9espfP1wQmIU1K0zH0viJTzmLXTvZLgZUEmBbPmCAAojLL4mN//LubNQJnaSnU4wg8zHFjVsAluAIg+bsg4AesgQtSe8isAbbdRWBmsEG3IAWso2RZzcGb4o7RXaHz7aLETwBKe0CwbgJZGZX2tQ/da0eWRtvltrcnjT3661f5SmYd5Fpi49EHD9reUUqsW+5wG+PWfnv+HZtWMCFdu3YXB4yk39aAJwUW2G49FKuOC2WzxN63Ue1vn/zALeBictcot6JouTMq7oTaFtnCJvgOoosLwT5+atnGxPaEUsXSte0ujuEuFFgiNS+XvnUtV3zDGaAA2rua01CTnmvbNxzsWHB75wv3v9f2LMRE5NP3LW8f2tFe2V0kAmOO9QTPVt3QmmY5EWm7xSKwW6U7PImL0pNZ8rfy/c3I37GoOg8cWEnlloHbGDa0lBJLRzzpr1s03yovVBbKjszEaJ/h+5TUcS2HheeWL2+z5J2Z1nRLEictSyrLKF35djdx0MQwaGrdXSRBT4Q6FXI+9wH1ncG8++w13VESgA2S7ri5kKHjZNV72jDqmoqoJxB1oyYCUoIY+N8ueHe4W0fGWU3A5rzgoIRncyDo7vTdoAnDtpr20Q+VfuZF11Jq/98UaMIYF5Sx4RqucUUdUJvXUw79LAyb9hqS7NXZl9vlfmKCE+Hj6vXL7uDyvlu3dAeWy7OpVdm6Zb7idJXWdgOrRQYNeO275kdVdWnU1kaJo7oylYWmjov1zD39p1/atcnaHcDtnHpx4x0789IfrM7XrQprbPe6zYprcZJfd1fyqb0Z2kth2NcX0fyUAkMxoIPCoZASce3tVffjZ35CctTdKGWQDWWSSvhQth7VFFyKGQq+9lw7ngSVWRMCL668H2WB3Sqd58R/4ZqsjDnvBE278I8wqGbnvPdf1GKQSGBC2GzLTyI1J5cIklXlrnRSAYXuZuyk+gYZEfEqEMnmZQaZJuSxznJXe37a+Py5EKb1s2WZ6fbV4dAjPclJMuEphkDTmKaIkKZIKeWt+Ty1PQTS24RebrFLFdRhXg8JyEglq7MM8GD8lLK1xp8XsHvyiW+us+ZIgHMeetObExGHBK7BTRLCTqQSmTkx2cQwqYUdYonknKyIY9h0JW7D6378jYfP7ArazJM/XPvgMC9f1wJbsFpbfX2SCKigQyLkZEqDEkZC6V/jtJMkvGGk9uZyvNUq/2HizYpET32tqk5gSotRm/388YcfKDN/PnW0fxoq+iCiFhbXTTt1wo2WycjZVl9trjjJqJd8ARF0OANb1ne8pDCgV+wufvKe7/3id/O1E8T88exjnz+0lGWvADwUqAIg1VKG72q3XFWprcX17qzzke4aEjpgAqSvObKnLwlUDX1/YzKLJ4796FdvbMFubXKrr9r9/rufPTwo4icG0T5F/yjy7WeHe1iIG94VLM7VlX6qCEgy8g9i1M9FXvzMJkhyFa5vMXiRS/D5qqueO/b4uX9p4naw/wDv1ZplvOGRpgAAAABJRU5ErkJggg==`;
+
+// src/components/styled/signInModalStyles.ts
+var COLOR_LIGHT_TEXT_MEDIUM = "#74777C";
+var ethosWalletTitleText = () => ({
+  fontSize: "18px",
+  lineHeight: "24px",
+  fontWeight: "600",
+  marginLeft: "10px"
+});
+var secondaryText = () => ({
+  color: "#6B7280",
+  fontSize: "0.875rem",
+  lineHeight: "1.25rem",
+  padding: "24px",
+  display: "flex",
+  flexDirection: "column",
+  gap: "12px"
+});
+var dialog = (isOpen) => ({
+  visibility: isOpen ? "" : "hidden",
+  position: "relative",
+  zIndex: "100"
+});
+var backdrop = (isOpen) => (
+  // fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity
+  {
+    position: "fixed",
+    top: "0px",
+    right: "0px",
+    bottom: "0px",
+    left: "0px",
+    backgroundColor: "rgb(107 114 128)",
+    opacity: isOpen ? ".75" : "0",
+    transition: "all 300ms ease-in-out"
+  }
+);
+var highlighted = () => ({
+  color: "#6D28D9"
+});
+var modalOuterWrapper = (isOpen) => (
+  // fixed z-10 inset-0 overflow-y-auto
+  {
+    position: "fixed",
+    zIndex: "99",
+    top: "0px",
+    right: "0px",
+    bottom: "0px",
+    left: "0px",
+    overflowY: "auto",
+    opacity: isOpen ? "1" : "0",
+    scale: isOpen ? "1" : ".95",
+    transition: "all 300ms ease-in-out"
+  }
+);
+var modalInnerWrapper = (width) => {
+  const styles = {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    minHeight: "100%",
+    padding: "1rem",
+    textAlign: "center"
+  };
+  const sm = {
+    padding: "0",
+    alignItems: "center"
+  };
+  return width < 640 /* sm */ ? styles : { ...styles, ...sm };
+};
+var dialogPanel = (width) => {
+  const styles = {
+    overflow: "hidden",
+    position: "relative",
+    backgroundColor: "#ffffff",
+    transitionProperty: "all",
+    borderRadius: "0.5rem",
+    boxShadow: "0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04)"
+  };
+  const sm = {
+    width: "360px"
+  };
+  return width < 640 /* sm */ ? styles : { ...styles, ...sm };
+};
+var topPanelStyle = () => ({
+  padding: "24px 24px 0px",
+  display: "flex",
+  flexDirection: "row",
+  justifyContent: "space-between",
+  alignItems: "center"
+});
+var closeStyle = () => ({
+  width: "24px",
+  height: "24px",
+  color: "#A0AEBA",
+  cursor: "pointer"
+});
+var backStyle = () => ({
+  color: COLOR_LIGHT_TEXT_MEDIUM,
+  cursor: "pointer",
+  display: "flex",
+  gap: "6px",
+  alignItems: "center"
+});
+var backStyleText = () => ({
+  fontSize: "16px",
+  lineHeight: "24px"
+});
+var headerStyle = (withIcon = false) => ({
+  padding: withIcon ? "24px 24px 32px" : "0 24px 32px",
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "center",
+  gap: "12px"
+});
+var headerLogosStyle = () => ({
+  display: "flex",
+  justifyContent: "center",
+  gap: "-6px"
+});
+var titleStyle = () => ({
+  fontSize: "24px",
+  fontWeight: "600",
+  lineHeight: "32px",
+  margin: "0"
+});
+var subTitleStyle = () => ({
+  fontSize: "16px",
+  fontWeight: "400",
+  lineHeight: "24px",
+  margin: "0",
+  color: COLOR_LIGHT_TEXT_MEDIUM
+});
+var strikeThroughOrContainer = () => ({
+  padding: "0px 24px 24px",
+  display: "flex",
+  flexDirection: "row",
+  gap: "12px",
+  justifyContent: "space-between",
+  alignItems: "center",
+  color: COLOR_LIGHT_TEXT_MEDIUM
+});
+var line = () => ({
+  height: "1px",
+  width: "100%",
+  background: "rgba(0, 0, 0, 0.12)",
+  borderRadius: "16px"
+});
+var emailInput = () => ({
+  boxSizing: "border-box",
+  border: "1px solid rgba(0, 0, 0, 0.08)",
+  borderRadius: "16px",
+  background: "#F2F2F2",
+  padding: "20px",
+  width: "100%"
+});
+var walletOptionContainer = (width) => {
+  const styles = {
+    padding: "0px 24px 24px",
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    gap: "12px"
+  };
+  const sm = {};
+  return width < 640 /* sm */ ? styles : { ...styles, ...sm };
+};
+var iconButton = (width, disabled = false, primary2 = false, noIcon = false) => {
+  const styles = {
+    textDecoration: "none",
+    fontWeight: primary2 ? "500" : "400",
+    boxSizing: "border-box",
+    display: "flex",
+    flexDirection: "row",
+    gap: "12px",
+    justifyContent: noIcon ? "center" : "space-between",
+    alignItems: "center",
+    padding: primary2 ? "20px 20px" : "16px 16px 16px 20px",
+    width: "100%",
+    background: primary2 ? "#6D28D9" : "#F2F2F2",
+    color: primary2 ? "white" : "black",
+    opacity: disabled ? 0.5 : 1,
+    cursor: disabled ? "not-allowed" : "pointer",
+    borderRadius: "16px",
+    flex: "none",
+    order: "0",
+    flexGrow: "0",
+    boxShadow: "0px 1px 2px rgba(0, 0, 0, 0.05)",
+    border: "none",
+    fontSize: "inherit"
+  };
+  const sm = {};
+  return width < 640 /* sm */ ? styles : { ...styles, ...sm };
+};
+var submitButtonContainer = () => ({
+  padding: "0px 24px 24px"
+});
+var loaderStyle = () => ({
+  display: "flex",
+  justifyContent: "center",
+  padding: "45px 0"
+});
+var walletExplanation = () => ({
+  padding: "6px 0",
+  color: "#666",
+  width: "100%",
+  fontSize: "smaller",
+  marginBottom: "12px"
+});
+
+// src/lib/useHandleElementWithIdClicked.ts
+import { useEffect } from "react";
+function useHandleElementWithIdClicked(clickId, onClickOutside) {
+  useEffect(() => {
+    function handleClickOutside(event2) {
+      if (event2.target.id === clickId) {
+        onClickOutside();
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, []);
+}
+
+// src/components/svg/EthosEnclosed.tsx
+var EthosEnclosed = ({ width = 24, color = "#6D28D9" }) => <svg width={width} height={width} viewBox="0 0 56 56" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="56" height="56" rx="16" fill={color} />
+  <path opacity="0.8" d="M17.9631 13H36.9268C37.7997 13 38.5073 13.7076 38.5073 14.5805V35.9802C38.5073 36.8531 37.7997 37.5607 36.9268 37.5607H17.9631C17.0902 37.5607 16.3826 36.8531 16.3826 35.9802V14.5805C16.3826 13.7076 17.0902 13 17.9631 13Z" stroke="url(#paint0_linear_514_2169)" strokeOpacity="0.9" strokeWidth="0.790251" />
+  <path d="M17.2471 14.0457L30.1651 20.0566C30.7225 20.316 31.0789 20.8749 31.0789 21.4896V42.6676C31.0789 43.8113 29.9018 44.5763 28.8566 44.112L15.9386 38.3725C15.3677 38.1189 14.9998 37.5528 14.9998 36.9281V15.4787C14.9998 14.3231 16.1994 13.5582 17.2471 14.0457Z" fill="white" fillOpacity="0.9" />
+  <path d="M42.9117 27.9093C43.0029 27.4813 43.219 27.0901 43.5329 26.7851C43.8467 26.4801 44.2441 26.2753 44.6746 26.1965L45.8205 25.9872L44.6745 25.7779H44.6746C44.2441 25.6991 43.8467 25.4943 43.5329 25.1893C43.219 24.8843 43.0029 24.4931 42.9117 24.0651L42.6596 22.8774L42.4074 24.0651C42.3162 24.4931 42.1001 24.8843 41.7862 25.1893C41.4724 25.4943 41.075 25.6992 40.6445 25.7779L39.4985 25.9872L40.6446 26.1965H40.6445C41.075 26.2753 41.4724 26.4801 41.7861 26.7851C42.1 27.0901 42.3162 27.4813 42.4073 27.9093L42.6595 29.097L42.9117 27.9093Z" fill="white" fillOpacity="0.9" />
+  <defs><linearGradient id="paint0_linear_514_2169" x1="38.5073" y1="19.5371" x2="27.4445" y2="25.0685" gradientUnits="userSpaceOnUse">
+    <stop stopColor="white" />
+    <stop offset="1" stopColor="white" stopOpacity="0" />
+  </linearGradient></defs>
+</svg>;
+var EthosEnclosed_default = EthosEnclosed;
+
+// src/components/svg/Ethos.tsx
+var Ethos = ({ width = 24, color = "#1e293b" }) => <svg
+  width={width}
+  height={width * 65 / 47}
+  viewBox="0 0 47 65"
+  fill="none"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <path
+    d="M6.00471 1H40.0029C42.7644 1 45.0029 3.23858 45.0029 6V44.8425C45.0029 47.604 42.7643 49.8425 40.0029 49.8425H6.0047C3.24328 49.8425 1.0047 47.604 1.0047 44.8425V6C1.0047 3.23858 3.24329 1 6.00471 1Z"
+    stroke={color}
+    strokeWidth="2"
+  />
+  <path
+    d="M6.68764 3.64648L30.6631 14.8026C32.0736 15.4589 32.9756 16.8735 32.9756 18.4292V58.6799C32.9756 61.5743 29.9966 63.5105 27.3515 62.3353L3.37601 51.683C1.93126 51.0411 1.00013 49.6085 1.00013 48.0276V7.27309C1.00013 4.34854 4.03609 2.41268 6.68764 3.64648Z"
+    fill={color}
+  />
+</svg>;
+var Ethos_default = Ethos;
+
+// src/components/styled/Header.tsx
+var Header = ({ title, subTitle, dappIcon, showEthos = false, children }) => {
+  return <div>
+    <div style={headerStyle(!!dappIcon)}>
+      <div style={headerLogosStyle()}>
+        {dappIcon && (typeof dappIcon === "string" ? <img src={dappIcon} /> : dappIcon)}
+        {showEthos && <Ethos_default />}
+      </div>
+      {title && <div style={titleStyle()}>{title}</div>}
+      {subTitle && <div style={subTitleStyle()}>{subTitle}</div>}
+    </div>
+    {children}
+  </div>;
+};
+var Header_default = Header;
+
+// src/components/styled/EmailSent.tsx
+var EmailSent = () => {
+  return <Header_default
+    title="Ethos sent you an email"
+    dappIcon={<EthosEnclosed_default width={60} />}
+  ><div style={secondaryText()}>
+    <p>An email has been sent to you with a link to login.</p>
+    <p>If you don't receive it, please check your spam folder or contact us at:</p>
+    <p>support@ethoswallet.xyz</p>
+  </div></Header_default>;
+};
+var EmailSent_default = EmailSent;
+
+// src/components/styled/Wallets.tsx
+import { useCallback } from "react";
+
+// src/components/styled/IconButton.tsx
+var IconButton = (props) => {
+  const { text, icon, width, disabled, primary: primary2, type, ...reactProps } = props;
+  return <button
+    style={iconButton(width, disabled, primary2, !icon)}
+    {...reactProps}
+    type={type}
+  >
+    <div>{text}</div>
+    {icon}
+  </button>;
+};
+var IconButton_default = IconButton;
+
+// src/components/styled/Wallets.tsx
+var Wallets = ({ wallets, selectWallet, width }) => {
+  const _connectExtension = useCallback((e) => {
+    if (!selectWallet)
+      return;
+    let element = e.target;
+    let name;
+    while (!name && element.parentNode) {
+      name = element.dataset.name;
+      element = element.parentNode;
+    }
+    selectWallet(name);
+  }, []);
+  const icon = useCallback((wallet) => {
+    const src = wallet.name === "Sui Wallet" ? "https://sui.io/favicon.png" : wallet.icon;
+    return <img src={src} height={32} width={32} />;
+  }, []);
+  return <div role="wallet-sign-in"><div style={walletOptionContainer(width)}>{wallets?.map(
+    (wallet, index) => <IconButton_default
+      key={`select-wallet-${index}`}
+      icon={icon(wallet)}
+      data-name={wallet.name}
+      text={wallet.name}
+      onClick={_connectExtension}
+      width={width}
+    />
+  )}</div></div>;
+};
+var Wallets_default = Wallets;
+
+// src/components/styled/Email.tsx
+import { useCallback as useCallback2, useMemo, useState } from "react";
+
+// src/lib/getConfiguration.ts
+import store from "store2";
+var getConfiguration = () => {
+  const ethosStore = store.namespace("ethos");
+  const configuration = ethosStore("configuration");
+  return configuration || {};
+};
+var getConfiguration_default = getConfiguration;
+
+// src/lib/postIFrameMessage.ts
+import store4 from "store2";
+
+// src/lib/getIframe.ts
+import store3 from "store2";
+
+// src/lib/log.ts
+import store2 from "store2";
+var allowLog = (label) => {
+  const logStore = store2.namespace("log");
+  const allowed = logStore("allowed") || [];
+  if (allowed.includes(label))
+    return;
+  logStore("allowed", [...allowed, label]);
+  return `Logging enabled for ${label}. Call ethos.clearAllowLog() to turn off this logging.`;
+};
+var clearAllowLog = () => {
+  const logStore = store2.namespace("log");
+  logStore("allowed", []);
+};
+var log = (label, ...message) => {
+  const logStore = store2.namespace("log");
+  const allowed = logStore("allowed");
+  if (!allowed || !(allowed.includes(label) || allowed.includes("all"))) {
+    return;
+  }
+  console.log(label, ...message);
+};
+if (typeof window !== "undefined") {
+  ;
+  window.ethos = {
+    allowLog,
+    clearAllowLog
+  };
+}
+var log_default = log;
+
+// src/lib/getIframe.ts
+var getIframe = (show) => {
+  const { apiKey, walletAppUrl } = getConfiguration_default();
+  log_default("getIframe", "getIframe", apiKey, walletAppUrl);
+  if (!apiKey || !walletAppUrl)
+    return;
+  const iframeId = "ethos-wallet-iframe";
+  let scrollY = 0;
+  let iframe = document.getElementById(iframeId);
+  const close = () => {
+    if (!iframe)
+      return;
+    iframe.style.width = "1px";
+    iframe.style.height = "1px";
+  };
+  const queryParams = new URLSearchParams(window.location.search);
+  const accessToken = queryParams.get("access_token");
+  const refreshToken = queryParams.get("refresh_token");
+  let fullWalletAppUrl = walletAppUrl + `/wallet?apiKey=${apiKey}`;
+  if (accessToken && refreshToken) {
+    fullWalletAppUrl += `&access_token=${accessToken}&refresh_token=${refreshToken}`;
+    queryParams.delete("access_token");
+    queryParams.delete("refresh_token");
+    let fullPath = location.protocol + "//" + location.host + location.pathname;
+    if (queryParams.toString().length > 0) {
+      fullPath += "?" + queryParams.toString();
+    }
+    store3.namespace("auth")("access_token", accessToken);
+    store3.namespace("auth")("refresh_token", refreshToken);
+    window.history.pushState({}, "", fullPath);
+  } else {
+    const accessToken2 = store3.namespace("auth")("access_token");
+    const refreshToken2 = store3.namespace("auth")("refresh_token");
+    if (accessToken2 && refreshToken2) {
+      fullWalletAppUrl += `&access_token=${accessToken2}&refresh_token=${refreshToken2}`;
+    }
+  }
+  if (!iframe) {
+    log_default("getIframe", "Load Iframe", fullWalletAppUrl);
+    iframe = document.createElement("IFRAME");
+    iframe.src = fullWalletAppUrl;
+    iframe.id = iframeId;
+    iframe.style.border = "none";
+    iframe.style.position = "absolute";
+    iframe.style.top = scrollY - 1 + "px";
+    iframe.style.right = "60px";
+    iframe.style.width = "1px";
+    iframe.style.height = "1px";
+    iframe.style.zIndex = "99";
+    iframe.style.backgroundColor = "transparent";
+    iframe.setAttribute("allow", "payment; clipboard-read; clipboard-write");
+    document.body.appendChild(iframe);
+    window.addEventListener("message", (message) => {
+      if (message.origin === walletAppUrl) {
+        const { action } = message.data;
+        switch (action) {
+          case "close":
+            close();
+            break;
+          case "ready":
+            iframe.setAttribute("readyToReceiveMessages", "true");
+            const messageStore = store3.namespace("iframeMessages");
+            const messages = messageStore("messages") || [];
+            for (const message2 of messages) {
+              postIFrameMessage_default(message2);
+            }
+            messageStore("messages", null);
+            break;
+        }
+      }
+    });
+    window.addEventListener("scroll", () => {
+      scrollY = window.scrollY;
+      iframe.style.top = scrollY + "px";
+    });
+  }
+  if (show) {
+    iframe.style.width = "360px";
+    iframe.style.height = "600px";
+  } else if (show !== void 0) {
+    close();
+  }
+  return iframe;
+};
+var getIframe_default = getIframe;
+
+// src/lib/postIFrameMessage.ts
+var postIFrameMessage = (message) => {
+  const iframe = getIframe_default();
+  if (!iframe?.getAttribute("readyToReceiveMessages")) {
+    const messageStore = store4.namespace("iframeMessages");
+    const existingMessages = messageStore("messages") || [];
+    const result = messageStore("messages", [...existingMessages, message]);
+    log_default("iframe", "Storing iframe message", result);
+    return;
+  }
+  iframe?.contentWindow?.postMessage(message, "*");
+};
+var postIFrameMessage_default = postIFrameMessage;
+
+// src/lib/event.ts
+var event = async (eventProps) => {
+  postIFrameMessage_default({
+    action: "event",
+    data: eventProps
+  });
+};
+var event_default = event;
+
+// src/lib/login.ts
+import store8 from "store2";
+
+// src/lib/getWalletContents.ts
+import { Connection, JsonRpcProvider } from "@mysten/sui.js";
+
+// src/lib/bigNumber.ts
+import BigNumber from "bignumber.js";
+var newBN = (value) => new BigNumber(value);
+var sumBN = (balance, addition) => {
+  let bn = new BigNumber(balance.toString());
+  let bnAddition = new BigNumber(addition.toString());
+  return bn.plus(bnAddition);
+};
+var formatBalance = (balance, decimals = 9) => {
+  if (balance === void 0)
+    return "---";
+  let postfix = "";
+  let bn = new BigNumber(balance.toString()).shiftedBy(-1 * decimals);
+  if (bn.gte(1e9)) {
+    bn = bn.shiftedBy(-9);
+    postfix = " B";
+  } else if (bn.gte(1e6)) {
+    bn = bn.shiftedBy(-6);
+    postfix = " M";
+  } else if (bn.gte(1e4)) {
+    bn = bn.shiftedBy(-3);
+    postfix = " K";
+  }
+  if (bn.gte(1)) {
+    bn = bn.decimalPlaces(3, BigNumber.ROUND_DOWN);
+  } else {
+    bn = bn.decimalPlaces(6, BigNumber.ROUND_DOWN);
+  }
+  return bn.toFormat() + postfix;
+};
+
+// src/lib/getBagNFT.ts
+import { getObjectFields, is, SuiObjectData } from "@mysten/sui.js";
+import _ from "lodash";
+var UrlDomainRegex = /0x2::dynamic_field::Field<(0x[a-f0-9]{39,40})::utils::Marker<(0x[a-f0-9]{39,40})::display::UrlDomain>, (0x[a-f0-9]{39,40})::display::UrlDomain>/;
+var DisplayDomainRegex = /0x2::dynamic_field::Field<(0x[a-f0-9]{39,40})::utils::Marker<(0x[a-f0-9]{39,40})::display::DisplayDomain>, (0x[a-f0-9]{39,40})::display::DisplayDomain>/;
+var ID_PATH = "reference.objectId";
+var BAG_ID_PATH = "data.fields.bag.fields.id.id";
+var LOGICAL_OWNER_PATH = "data.fields.logical_owner";
+var isTypeMatchRegex = (d, regex) => {
+  const { data } = d;
+  if (is(data, SuiObjectData)) {
+    const { content } = data;
+    if (content && "type" in content) {
+      return content.type.match(regex);
+    }
+  }
+  return false;
+};
+var parseDomains = (domains) => {
+  const response = {};
+  const urlDomain = domains.find((d) => isTypeMatchRegex(d, UrlDomainRegex));
+  const displayDomain = domains.find(
+    (d) => isTypeMatchRegex(d, DisplayDomainRegex)
+  );
+  if (urlDomain && getObjectFields(urlDomain)) {
+    const url = getObjectFields(urlDomain).value.fields.url;
+    response.url = ipfsConversion(url);
+  }
+  if (displayDomain && getObjectFields(displayDomain)) {
+    response.description = getObjectFields(displayDomain).value.fields.description;
+    response.name = getObjectFields(displayDomain).value.fields.name;
+  }
+  return response;
+};
+var isBagNFT = (data) => {
+  return !!data.content && "fields" in data.content && "logical_owner" in data.content.fields && "bag" in data.content.fields;
+};
+var getBagNFT = async (provider, data) => {
+  if (!isBagNFT(data) || !_.has(data, ID_PATH) || !_.has(data, BAG_ID_PATH) || !_.has(data, LOGICAL_OWNER_PATH))
+    return data;
+  const id = _.get(data, ID_PATH);
+  const bagId = _.get(data, BAG_ID_PATH);
+  const owner = _.get(data, LOGICAL_OWNER_PATH);
+  const bagObjects = await provider.getDynamicFields({ parentId: bagId || "" });
+  const objectIds = bagObjects.data.map((bagObject) => bagObject.objectId);
+  const objects = await provider.multiGetObjects({
+    ids: objectIds,
+    options: {
+      showContent: true,
+      showDisplay: true,
+      showOwner: true,
+      showType: true
+    }
+  });
+  return {
+    id,
+    owner,
+    ...parseDomains(objects)
+  };
+};
+var getBagNFT_default = getBagNFT;
+
+// src/enums/Chain.ts
+var Chain = /* @__PURE__ */ ((Chain2) => {
+  Chain2["SUI_DEVNET"] = "sui:devnet";
+  Chain2["SUI_TESTNET"] = "sui:testnet";
+  Chain2["SUI_CUSTOM"] = "sui:custom";
+  return Chain2;
+})(Chain || {});
+
+// src/lib/constants.ts
+var primaryColor = "#6f53e4";
+var appBaseUrl = typeof window !== "undefined" && window.location.origin.indexOf("http://localhost") === 0 ? "http://localhost:3000" : "https://ethoswallet.onrender.com";
+var DEFAULT_NETWORK = "https://fullnode.devnet.sui.io/";
+var DEFAULT_FAUCET = "https://faucet.devnet.sui.io/";
+var DEFAULT_CHAIN = "sui:devnet" /* SUI_DEVNET */;
+
+// src/lib/getDisplay.ts
+var getDisplay = (display) => {
+  if (!display)
+    return;
+  if (display?.data && typeof display?.data === "object") {
+    return display.data;
+  }
+  if (!("error" in display))
+    return display;
+  return;
+};
+var getDisplay_default = getDisplay;
+
+// src/lib/getWalletContents.ts
+var ipfsConversion = (src) => {
+  if (!src)
+    return "";
+  if (src.indexOf("ipfs") === 0) {
+    src = `https://ipfs.io/ipfs/${src.substring(5)}`;
+  }
+  return src;
+};
+var empty = {
+  suiBalance: newBN(0),
+  nfts: [],
+  tokens: {},
+  objects: []
+};
+var getWalletContents = async ({ address: address2, network, existingContents }) => {
+  try {
+    const connection = new Connection({ fullnode: network || DEFAULT_NETWORK });
+    const provider = new JsonRpcProvider(connection);
+    if (!address2) {
+      return empty;
+    }
+    const objectInfos = await provider.getOwnedObjects({
+      owner: address2,
+      options: {
+        showType: true,
+        showOwner: true,
+        showContent: true,
+        showDisplay: true
+      }
+    });
+    if (objectInfos.data.length === 0) {
+      if (existingContents === empty) {
+        return null;
+      }
+      return empty;
+    }
+    const currentObjects = [];
+    let newObjectInfos = [];
+    if (existingContents?.objects && existingContents.objects.length > 0) {
+      for (const objectInfo of objectInfos.data) {
+        if (!objectInfo.data || objectInfo.error)
+          continue;
+        const existingObject = existingContents?.objects.find(
+          (existingObject2) => {
+            if (typeof objectInfo.data === "object" && typeof existingObject2.data === "object") {
+              return existingObject2.data.objectId === objectInfo.data.objectId && existingObject2.data.version === objectInfo.data.version;
+            } else {
+              return false;
+            }
+          }
+        );
+        if (existingObject) {
+          currentObjects.push(existingObject);
+        } else {
+          newObjectInfos.push(objectInfo);
+        }
+      }
+    } else {
+      newObjectInfos = objectInfos.data;
+    }
+    if (newObjectInfos.length === 0)
+      return null;
+    const newObjects = newObjectInfos;
+    const objects = currentObjects.concat(newObjects);
+    let suiBalance = newBN(0);
+    const nfts = [];
+    const tokens = {};
+    const convenenienceObjects = [];
+    for (const object of objects) {
+      const { data } = object;
+      if (!data)
+        continue;
+      const { display, content: { fields } } = data;
+      const safeDisplay = getDisplay_default(display);
+      try {
+        const typeStringComponents = (data.type || "").split("<");
+        const subtype = (typeStringComponents[1] || "").replace(/>/, "");
+        const typeComponents = typeStringComponents[0].split("::");
+        const type = typeComponents[typeComponents.length - 1];
+        const { name, description, ...extraFields } = fields ?? {};
+        convenenienceObjects.push({
+          ...object,
+          type: data?.type,
+          version: data?.version,
+          objectId: data?.objectId,
+          name,
+          description,
+          display: safeDisplay,
+          extraFields
+        });
+        if (type === "Coin") {
+          if (subtype === "0x2::sui::SUI") {
+            suiBalance = sumBN(suiBalance, fields.balance);
+          }
+          tokens[subtype] ||= {
+            balance: 0,
+            coins: []
+          };
+          tokens[subtype].balance = sumBN(tokens[subtype].balance, fields.balance);
+          tokens[subtype].coins.push({
+            objectId: data?.objectId,
+            type: data?.type,
+            balance: newBN(fields.balance),
+            digest: data?.digest,
+            version: data?.version,
+            display: safeDisplay
+          });
+        } else if (isBagNFT(object.data)) {
+          const bagNFT = await getBagNFT_default(provider, object.data);
+          if ("name" in bagNFT) {
+            nfts.push({
+              type: data?.type,
+              package: typeComponents[0],
+              chain: "Sui",
+              address: data?.objectId,
+              objectId: data?.objectId,
+              name: safeDisplay?.name ?? bagNFT.name,
+              description: safeDisplay?.name ?? bagNFT.description,
+              imageUri: ipfsConversion(safeDisplay?.image_url ?? bagNFT.url),
+              link: safeDisplay?.link,
+              creator: safeDisplay?.creator,
+              projectUrl: safeDisplay?.project_url,
+              display: safeDisplay,
+              module: typeComponents[1],
+              links: {
+                "Explorer": `https://explorer.sui.io/objects/${object?.objectId}`
+              }
+            });
+          }
+        } else {
+          const { url, image_url, image, ...remaining } = extraFields || {};
+          const safeUrl = ipfsConversion(safeDisplay?.image_url || url || image_url || image);
+          if (safeUrl) {
+            nfts.push({
+              type: data?.type,
+              package: typeComponents[0],
+              chain: "Sui",
+              address: data?.objectId,
+              objectId: data?.objectId,
+              name: safeDisplay?.name ?? name,
+              description: safeDisplay?.description ?? description,
+              imageUri: safeUrl,
+              link: safeDisplay?.link,
+              creator: safeDisplay?.creator,
+              projectUrl: safeDisplay?.project_url,
+              display: safeDisplay,
+              extraFields: remaining,
+              module: typeComponents[1],
+              links: {
+                "Explorer": `https://explorer.sui.io/objects/${object?.objectId}`
+              }
+            });
+          }
+        }
+      } catch (error) {
+        console.log("Error retrieving object", object, error);
+      }
+    }
+    return { suiBalance, tokens, nfts, objects: convenenienceObjects };
+  } catch (error) {
+    console.log("Error retrieving wallet contents", error);
+    return null;
+  }
+};
+var getWalletContents_default = getWalletContents;
+
+// src/lib/getEthosSigner.ts
+import store6 from "store2";
+
+// src/lib/activeUser.ts
+var activeUser = () => {
+  log_default("activeUser", "Calling Active User");
+  const { walletAppUrl, apiKey } = getConfiguration_default();
+  log_default("activeUser", "Configuration", walletAppUrl, apiKey);
+  const resolver = (resolve) => {
+    const listener = (message2) => {
+      log_default("activeUser", "Message Origin: ", message2.origin, walletAppUrl, message2);
+      if (message2.origin === walletAppUrl) {
+        const { action, data } = message2.data;
+        log_default("activeUser", "Message From Wallet", action, data);
+        if (action === "user" && data.apiKey === apiKey) {
+          window.removeEventListener("message", listener);
+          resolve(data?.user);
+        }
+      }
+    };
+    window.addEventListener("message", listener);
+    const message = { action: "activeUser" };
+    log_default("activeUser", "getIframe");
+    getIframe_default();
+    log_default('activeUser", "Post message to the iframe', message);
+    postIFrameMessage_default(message);
+  };
+  return new Promise(resolver);
+};
+var activeUser_default = activeUser;
+
+// src/lib/hostedInteraction.ts
+import store5 from "store2";
+var hostedInteraction = ({ id, action, data, onResponse, showWallet: showWallet2 = false }) => {
+  const { walletAppUrl } = getConfiguration_default();
+  const iframeListener = (message) => {
+    log_default("hostedInteraction", "response: ", message);
+    if (message.origin === walletAppUrl) {
+      const { approved, action: responseAction, data: responseData } = message.data;
+      if (responseAction !== action)
+        return;
+      onResponse({ approved, data: responseData });
+      window.removeEventListener("message", iframeListener);
+      getIframe_default(false);
+    }
+  };
+  window.addEventListener("message", iframeListener);
+  const ethosStore = store5.namespace("ethos");
+  const configuration = ethosStore("configuration");
+  const { network } = configuration;
+  log_default("hostedInteraction", "Posting interaction", id, action, data);
+  postIFrameMessage_default({ id, network, action, data });
+  getIframe_default(showWallet2);
+};
+var hostedInteraction_default = hostedInteraction;
+
+// src/lib/getEthosSigner.ts
+var getEthosSigner = async ({ defaultChain }) => {
+  const user = await activeUser_default();
+  const accounts = (user?.accounts || []).filter((account) => account.chain === "sui");
+  const currentAccount = accounts[0];
+  const signAndExecuteTransactionBlock = (input) => {
+    return new Promise((resolve, reject) => {
+      const transactionEventListener = ({ approved, data }) => {
+        if (approved) {
+          resolve(data.response);
+        } else {
+          reject({ error: data?.response?.error || "User rejected transaction." });
+        }
+      };
+      const serializedTransaction = input.transactionBlock.serialize();
+      const account = input.account ?? currentAccount.address;
+      const chain = input.chain ?? defaultChain ?? DEFAULT_CHAIN;
+      hostedInteraction_default({
+        action: "transaction",
+        data: {
+          input,
+          serializedTransaction,
+          account,
+          chain
+        },
+        onResponse: transactionEventListener,
+        showWallet: true
+      });
+    });
+  };
+  const signTransactionBlock = (input) => {
+    return new Promise((resolve, reject) => {
+      const transactionEventListener = ({ approved, data }) => {
+        if (approved) {
+          resolve(data.response);
+        } else {
+          reject({ error: data?.response?.error || "User rejected transaction." });
+        }
+      };
+      const serializedTransaction = input.transactionBlock.serialize();
+      const account = input.account ?? currentAccount.address;
+      const chain = input.chain ?? defaultChain ?? DEFAULT_CHAIN;
+      hostedInteraction_default({
+        action: "transaction",
+        data: {
+          input,
+          serializedTransaction,
+          account,
+          chain
+        },
+        onResponse: transactionEventListener,
+        showWallet: true
+      });
+    });
+  };
+  const requestPreapproval = () => {
+    return Promise.resolve(true);
+  };
+  const signMessage = (input) => {
+    return new Promise((resolve, reject) => {
+      const transactionEventListener = ({ approved, data }) => {
+        if (approved) {
+          resolve(data.response);
+        } else {
+          reject({ error: data?.response?.error || "User rejected signing." });
+        }
+      };
+      hostedInteraction_default({
+        action: "sign",
+        data: { ...input, signData: input.message },
+        onResponse: transactionEventListener,
+        showWallet: true
+      });
+    });
+  };
+  const disconnect = (fromWallet = false) => {
+    return new Promise((resolve) => {
+      const transactionEventListener = () => {
+        resolve(true);
+      };
+      hostedInteraction_default({
+        action: "logout",
+        data: {
+          fromWallet: typeof fromWallet === "boolean" ? fromWallet : false
+        },
+        onResponse: transactionEventListener
+      });
+      store6.namespace("auth")("access_token", null);
+    });
+  };
+  const logout2 = () => {
+    return disconnect(true);
+  };
+  return user ? {
+    type: "hosted" /* Hosted */,
+    name: "Ethos",
+    icon: dataIcon,
+    email: user.email,
+    getAddress: async () => currentAccount?.address,
+    accounts,
+    currentAccount,
+    signAndExecuteTransactionBlock,
+    signTransactionBlock,
+    requestPreapproval,
+    signMessage,
+    disconnect,
+    logout: logout2
+  } : null;
+};
+var getEthosSigner_default = getEthosSigner;
+var dataIcon = `data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzIiIGhlaWdodD0iMzIiIHZpZXdCb3g9IjAgMCAzMiAzMiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHJlY3Qgd2lkdGg9IjMyIiBoZWlnaHQ9IjMyIiByeD0iOCIgZmlsbD0iIzZEMjhEOSIvPgo8cGF0aCBvcGFjaXR5PSIwLjgiIGQ9Ik05LjEyMTg3IDYuODU3MDZIMTkuOTU4M0MyMC40NTcxIDYuODU3MDYgMjAuODYxNCA3LjI2MTQxIDIwLjg2MTQgNy43NjAyVjE5Ljk4ODZDMjAuODYxNCAyMC40ODc0IDIwLjQ1NzEgMjAuODkxOCAxOS45NTgzIDIwLjg5MThIOS4xMjE4N0M4LjYyMzA4IDIwLjg5MTggOC4yMTg3MiAyMC40ODc0IDguMjE4NzIgMTkuOTg4NlY3Ljc2MDJDOC4yMTg3MiA3LjI2MTQxIDguNjIzMDggNi44NTcwNiA5LjEyMTg3IDYuODU3MDZaIiBzdHJva2U9InVybCgjcGFpbnQwX2xpbmVhcl82OTlfMjY5OCkiIHN0cm9rZS13aWR0aD0iMC40NTE1NzIiLz4KPHBhdGggZD0iTTguNzEyNzQgNy40NTQ1OUwxNi4wOTQ1IDEwLjg4OTRDMTYuNDEyOSAxMS4wMzc2IDE2LjYxNjYgMTEuMzU3IDE2LjYxNjYgMTEuNzA4M1YyMy44MUMxNi42MTY2IDI0LjQ2MzUgMTUuOTQ0IDI0LjkwMDcgMTUuMzQ2OCAyNC42MzUzTDcuOTY1MDIgMjEuMzU1NkM3LjYzODgyIDIxLjIxMDcgNy40Mjg1OCAyMC44ODcyIDcuNDI4NTggMjAuNTMwM1Y4LjI3MzQzQzcuNDI4NTggNy42MTMxMSA4LjExNDA2IDcuMTc2MDIgOC43MTI3NCA3LjQ1NDU5WiIgZmlsbD0id2hpdGUiLz4KPHBhdGggZD0iTTIzLjM3ODIgMTUuMzc2N0MyMy40MzAzIDE1LjEzMjEgMjMuNTUzOCAxNC45MDg2IDIzLjczMzIgMTQuNzM0M0MyMy45MTI1IDE0LjU2IDI0LjEzOTYgMTQuNDQzIDI0LjM4NTYgMTQuMzk3OUwyNS4wNDA0IDE0LjI3ODRMMjQuMzg1NSAxNC4xNTg4SDI0LjM4NTZDMjQuMTM5NiAxNC4xMTM3IDIzLjkxMjUgMTMuOTk2NyAyMy43MzMyIDEzLjgyMjRDMjMuNTUzOCAxMy42NDgxIDIzLjQzMDMgMTMuNDI0NiAyMy4zNzgyIDEzLjE4TDIzLjIzNDEgMTIuNTAxM0wyMy4wOSAxMy4xOEMyMy4wMzc5IDEzLjQyNDYgMjIuOTE0NCAxMy42NDgxIDIyLjczNTEgMTMuODIyNEMyMi41NTU4IDEzLjk5NjcgMjIuMzI4NyAxNC4xMTM4IDIyLjA4MjcgMTQuMTU4OEwyMS40Mjc4IDE0LjI3ODRMMjIuMDgyNyAxNC4zOTc5SDIyLjA4MjdDMjIuMzI4NyAxNC40NDMgMjIuNTU1NyAxNC41NiAyMi43MzUgMTQuNzM0M0MyMi45MTQ0IDE0LjkwODYgMjMuMDM3OSAxNS4xMzIxIDIzLjA5IDE1LjM3NjdMMjMuMjM0MSAxNi4wNTU0TDIzLjM3ODIgMTUuMzc2N1oiIGZpbGw9IndoaXRlIi8+CjxkZWZzPgo8bGluZWFyR3JhZGllbnQgaWQ9InBhaW50MF9saW5lYXJfNjk5XzI2OTgiIHgxPSIyMC44NjE0IiB5MT0iMTAuNTkyNiIgeDI9IjE0LjUzOTgiIHkyPSIxMy43NTM0IiBncmFkaWVudFVuaXRzPSJ1c2VyU3BhY2VPblVzZSI+CjxzdG9wIHN0b3AtY29sb3I9IndoaXRlIi8+CjxzdG9wIG9mZnNldD0iMSIgc3RvcC1jb2xvcj0id2hpdGUiIHN0b3Atb3BhY2l0eT0iMCIvPgo8L2xpbmVhckdyYWRpZW50Pgo8L2RlZnM+Cjwvc3ZnPgo=`;
+
+// src/lib/initializeEthos.ts
+import store7 from "store2";
+var initializeEthos = (ethosConfiguration) => {
+  const ethosStore = store7.namespace("ethos");
+  log_default("initialize", "Ethos Configuration", ethosConfiguration);
+  ethosStore("configuration", ethosConfiguration);
+};
+var initializeEthos_default = initializeEthos;
+
+// src/lib/listenForMobileConnection.ts
+var listenForMobileConnection = async () => {
+  const { walletAppUrl } = getConfiguration_default();
+  const connectionEventListener = (message) => {
+    if (message.origin === walletAppUrl) {
+      const { action, data } = message.data;
+      if (action !== "connect")
+        return;
+      if (!data.address) {
+        return;
+      }
+      ;
+      window.removeEventListener("message", connectionEventListener);
+      const signer = {
+        currentAccount: { address: data.address }
+      };
+      const provider = {
+        getSigner: signer
+      };
+      log_default("mobile", "Mobile connection established", provider, signer);
+    }
+  };
+  window.removeEventListener("message", connectionEventListener);
+  window.addEventListener("message", connectionEventListener);
+};
+var listenForMobileConnection_default = listenForMobileConnection;
+
+// src/lib/lib.ts
+var lib = {
+  // showWallet,
+  // hideWallet,
+  // login,
+  // logout,
+  // transact,
+  // preapprove,
+  getWalletContents: getWalletContents_default,
+  // dripSui,
+  postIFrameMessage: postIFrameMessage_default,
+  getEthosSigner: getEthosSigner_default,
+  getConfiguration: getConfiguration_default,
+  initializeEthos: initializeEthos_default,
+  listenForMobileConnection: listenForMobileConnection_default
+};
+var lib_default = lib;
+
+// src/lib/login.ts
+var login = async ({ email, provider, apiKey }) => {
+  const { walletAppUrl, redirectTo } = lib_default.getConfiguration();
+  const userStore = store8.namespace("users");
+  if (provider) {
+    const returnTo = redirectTo ?? location.href;
+    const fullUrl = `${walletAppUrl}/auth?apiKey=${apiKey}&returnTo=${encodeURIComponent(returnTo)}`;
+    location.href = `${walletAppUrl}/socialauth?provider=${provider}&redirectTo=${encodeURIComponent(fullUrl)}`;
+    return;
+  }
+  return new Promise((resolve, _reject) => {
+    const loginEventListener = (message) => {
+      if (message.origin === walletAppUrl) {
+        const { action, data } = message.data;
+        if (action !== "login")
+          return;
+        window.removeEventListener("message", loginEventListener);
+        userStore("current", data);
+        resolve(data);
+      }
+    };
+    window.addEventListener("message", loginEventListener);
+    lib_default.postIFrameMessage({
+      action: "login",
+      data: {
+        email,
+        provider,
+        returnTo: redirectTo ?? window.location.href,
+        apiKey
+      }
+    });
+  });
+};
+var login_default = login;
+
+// src/components/styled/Email.tsx
+var Email = ({ setSigningIn, setEmailSent, width }) => {
+  const { apiKey } = getConfiguration_default();
+  const [email, setEmail] = useState("");
+  const validEmail = useMemo(() => {
+    if (!email)
+      return false;
+    if (email.length === 0)
+      return false;
+    return !!email.match(/(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9]))\.){3}(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9])|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])/);
+  }, [email]);
+  const sendEmail = useCallback2(async () => {
+    if (!validEmail)
+      return;
+    await login_default({ email, apiKey });
+    setEmail("");
+    setSigningIn(false);
+    setEmailSent(true);
+    event_default({ action: "send_email", category: "sign_in", label: email, value: 1 });
+  }, [validEmail, login_default, email, apiKey]);
+  const _handleChange = useCallback2((e) => {
+    setEmail(e.target.value);
+  }, []);
+  const onSubmit = useCallback2(async (e) => {
+    if (!validEmail) {
+      e.preventDefault();
+      return;
+    }
+    setSigningIn(true);
+    sendEmail();
+  }, [sendEmail]);
+  return <div role="email-sign-in">
+    <form onSubmit={onSubmit} style={walletOptionContainer(width)}>
+      <input
+        style={emailInput()}
+        type="email"
+        placeholder="Enter your email address..."
+        value={email}
+        onChange={_handleChange}
+      />
+      <IconButton_default
+        text="Sign In With Email"
+        type="submit"
+        width={width}
+        disabled={!validEmail}
+        primary={true}
+      />
+    </form>
+    {
+      /* <div style={{ display: 'none', marginLeft: "-12px" }}>
+          <ReCAPTCHA
+              sitekey={captchaSiteKey}
+              ref={captchaRef}
+              size="invisible"
+              onChange={sendEmail}
+          />
+      </div> */
+    }
+  </div>;
+};
+var Email_default = Email;
+
+// src/components/styled/FontProvider.tsx
+var FontProvider = ({ children }) => {
+  const styles = () => ({
+    fontFamily: "'Inter', sans-serif",
+    color: "black",
+    lineHeight: "1.5",
+    fontSize: "16px"
+  });
+  return <>
+    <link href="https://rsms.me/inter/inter.css" rel="stylesheet" />
+    <div style={styles()}>{children}</div>
+  </>;
+};
+var FontProvider_default = FontProvider;
+
+// src/components/styled/Dialog.tsx
+var Dialog = ({ isOpenAll, children }) => {
+  return <FontProvider_default><div style={dialog(isOpenAll)} role="dialog">
+    <div style={backdrop(isOpenAll)} />
+    {children}
+  </div></FontProvider_default>;
+};
+var Dialog_default = Dialog;
+
+// src/components/styled/ModalWrapper.tsx
+var ModalWrapper = ({ closeOnClickId, onClose, isOpenAll, width, back, children }) => {
+  return <div style={modalOuterWrapper(isOpenAll)}><div id={closeOnClickId} style={modalInnerWrapper(width)}><div style={dialogPanel(width)}>
+    <div style={topPanelStyle()}>
+      <span>{back && <span style={backStyle()} onClick={back}>
+        {"\u2190"}
+        <span style={backStyleText()}>Back</span>
+      </span>}</span>
+      <span style={closeStyle()} onClick={onClose}><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" /></svg></span>
+    </div>
+    {children}
+  </div></div></div>;
+};
+var ModalWrapper_default = ModalWrapper;
+
+// src/components/svg/InstallWalletIcon.tsx
+var InstallWalletIcon = ({ width = 60 }) => {
+  return <svg width={width} height={width} viewBox="0 0 60 60" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect x="1" y="1" width="58" height="58" rx="17" fill="#1A1C26" />
+    <path d="M17.0307 21.5C18.1258 20.5314 19.538 19.9977 21 20H39C40.5213 20 41.9107 20.5667 42.9693 21.5C42.8475 20.5332 42.377 19.6442 41.6462 18.9998C40.9153 18.3553 39.9744 17.9998 39 18H21C20.0256 17.9998 19.0847 18.3553 18.3538 18.9998C17.623 19.6442 17.1525 20.5332 17.0307 21.5ZM17.0307 25.5C18.1258 24.5314 19.538 23.9977 21 24H39C40.5213 24 41.9107 24.5667 42.9693 25.5C42.8475 24.5332 42.377 23.6442 41.6462 22.9998C40.9153 22.3553 39.9744 21.9998 39 22H21C20.0256 21.9998 19.0847 22.3553 18.3538 22.9998C17.623 23.6442 17.1525 24.5332 17.0307 25.5ZM21 26C19.9391 26 18.9217 26.4214 18.1716 27.1716C17.4214 27.9217 17 28.9391 17 30V38C17 39.0609 17.4214 40.0783 18.1716 40.8284C18.9217 41.5786 19.9391 42 21 42H39C40.0609 42 41.0783 41.5786 41.8284 40.8284C42.5786 40.0783 43 39.0609 43 38V30C43 28.9391 42.5786 27.9217 41.8284 27.1716C41.0783 26.4214 40.0609 26 39 26H34C33.7348 26 33.4804 26.1054 33.2929 26.2929C33.1054 26.4804 33 26.7348 33 27C33 27.7956 32.6839 28.5587 32.1213 29.1213C31.5587 29.6839 30.7956 30 30 30C29.2044 30 28.4413 29.6839 27.8787 29.1213C27.3161 28.5587 27 27.7956 27 27C27 26.7348 26.8946 26.4804 26.7071 26.2929C26.5196 26.1054 26.2652 26 26 26H21Z" fill="white" />
+    <rect x="1" y="1" width="58" height="58" rx="17" stroke="#060914" strokeWidth="2" />
+  </svg>;
+};
+var InstallWalletIcon_default = InstallWalletIcon;
+
+// src/components/svg/SuiEnclosed.tsx
+var SuiEnclosed = ({ width = 32 }) => {
+  return <svg width={width} height={width} viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect width="32" height="32" rx="8" fill="#81BAEB" />
+    <g clipPath="url(#clip0_315_6756)"><path fillRule="evenodd" clipRule="evenodd" d="M10.4932 22.2659C11.0635 23.2776 11.8925 24.1195 12.8953 24.7053C13.898 25.2912 15.0385 25.5999 16.1999 25.5999C17.3613 25.5999 18.5017 25.2912 19.5045 24.7053C20.5073 24.1195 21.3363 23.2776 21.9066 22.2659C22.4918 21.2523 22.7999 20.1025 22.7999 18.932C22.7999 17.7616 22.4918 16.6118 21.9066 15.5982L16.8874 6.80155C16.8187 6.67967 16.7188 6.57825 16.598 6.50767C16.4772 6.4371 16.3398 6.3999 16.1999 6.3999C16.06 6.3999 15.9226 6.4371 15.8018 6.50767C15.6809 6.57825 15.5811 6.67967 15.5123 6.80155L10.4932 15.5982C9.90796 16.6118 9.59985 17.7616 9.59985 18.932C9.59985 20.1025 9.90796 21.2523 10.4932 22.2659ZM14.786 10.9865L15.8561 9.11092C15.8905 9.04998 15.9404 8.99927 16.0008 8.96399C16.0612 8.9287 16.1299 8.9101 16.1999 8.9101C16.2698 8.9101 16.3385 8.9287 16.399 8.96399C16.4594 8.99927 16.5093 9.04998 16.5437 9.11092L20.6605 16.3263C21.0301 16.966 21.2592 17.6771 21.3326 18.4123C21.4061 19.1475 21.3221 19.8898 21.0864 20.59C21.0352 20.3514 20.9648 20.1172 20.8758 19.8899C20.3072 18.4377 19.0214 17.3171 17.0534 16.559C15.7004 16.0397 14.8368 15.276 14.4859 14.2886C14.0339 13.0166 14.506 11.6291 14.786 10.9865ZM12.9612 14.1847L11.7392 16.3263C11.2817 17.1186 11.0409 18.0174 11.0409 18.9323C11.0409 19.8472 11.2817 20.7459 11.7392 21.5382C12.1091 22.1934 12.6186 22.7591 13.2316 23.1952C13.8447 23.6312 14.5462 23.927 15.2864 24.0615C16.0266 24.1959 16.7874 24.1658 17.5146 23.9732C18.2419 23.7806 18.9178 23.4302 19.4944 22.947C19.8131 22.1324 19.8244 21.2296 19.5264 20.4072C19.1088 19.358 18.1034 18.5204 16.5383 17.9172C14.7692 17.2381 13.6199 16.178 13.1228 14.7672C13.0558 14.5769 13.0019 14.3823 12.9612 14.1847Z" fill="white" /></g>
+    <defs><clipPath id="clip0_315_6756"><rect width="19.2" height="19.2" fill="white" transform="translate(6.3999 6.3999)" /></clipPath></defs>
+  </svg>;
+};
+var SuiEnclosed_default = SuiEnclosed;
+
+// src/components/svg/EthosWalletIcon.tsx
+var EthosWalletIcon = () => {
+  return <svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect width="32" height="32" rx="8" fill="#6D28D9" />
+    <path opacity="0.8" d="M9.12187 6.85706H19.9583C20.4571 6.85706 20.8614 7.26141 20.8614 7.7602V19.9886C20.8614 20.4874 20.4571 20.8918 19.9583 20.8918H9.12187C8.62308 20.8918 8.21872 20.4874 8.21872 19.9886V7.7602C8.21872 7.26141 8.62308 6.85706 9.12187 6.85706Z" stroke="url(#paint0_linear_699_2698)" strokeWidth="0.451572" />
+    <path d="M8.71274 7.45459L16.0945 10.8894C16.4129 11.0376 16.6166 11.357 16.6166 11.7083V23.81C16.6166 24.4635 15.944 24.9007 15.3468 24.6353L7.96502 21.3556C7.63882 21.2107 7.42858 20.8872 7.42858 20.5303V8.27343C7.42858 7.61311 8.11406 7.17602 8.71274 7.45459Z" fill="white" />
+    <path d="M23.3782 15.3767C23.4303 15.1321 23.5538 14.9086 23.7332 14.7343C23.9125 14.56 24.1396 14.443 24.3856 14.3979L25.0404 14.2784L24.3855 14.1588H24.3856C24.1396 14.1137 23.9125 13.9967 23.7332 13.8224C23.5538 13.6481 23.4303 13.4246 23.3782 13.18L23.2341 12.5013L23.09 13.18C23.0379 13.4246 22.9144 13.6481 22.7351 13.8224C22.5558 13.9967 22.3287 14.1138 22.0827 14.1588L21.4278 14.2784L22.0827 14.3979H22.0827C22.3287 14.443 22.5557 14.56 22.735 14.7343C22.9144 14.9086 23.0379 15.1321 23.09 15.3767L23.2341 16.0554L23.3782 15.3767Z" fill="white" />
+    <defs><linearGradient id="paint0_linear_699_2698" x1="20.8614" y1="10.5926" x2="14.5398" y2="13.7534" gradientUnits="userSpaceOnUse">
+      <stop stopColor="white" />
+      <stop offset="1" stopColor="white" stopOpacity="0" />
+    </linearGradient></defs>
+  </svg>;
+};
+var EthosWalletIcon_default = EthosWalletIcon;
+
+// src/components/styled/InstallWallet.tsx
+var InstallWallet = ({ walletInfos, width }) => {
+  const icon = (data) => {
+    if (!data)
+      return <></>;
+    if (typeof data === "string") {
+      return <img src={data} height={32} width={32} />;
+    }
+    return data;
+  };
+  const installWallets = [
+    {
+      name: "Ethos Wallet",
+      icon: <EthosWalletIcon_default />,
+      link: "https://chrome.google.com/webstore/detail/ethos-wallet/mcbigmjiafegjnnogedioegffbooigli"
+    },
+    {
+      name: "Sui Wallet",
+      icon: <SuiEnclosed_default />,
+      link: "https://chrome.google.com/webstore/detail/sui-wallet/opcgpfmipidbgpenhmajoajpbobppdil"
+    },
+    ...walletInfos || []
+  ];
+  return <Header_default
+    dappIcon={<InstallWalletIcon_default />}
+    title="Install A Wallet"
+    subTitle="Wallets allow you to interact with, store, send, and receive digital assets."
+  ><div role="wallet-sign-in"><div style={walletOptionContainer(width)}>{installWallets?.map(
+    (installWallet, index) => <a
+      key={`install-wallet-${index}`}
+      style={iconButton(width)}
+      href={installWallet.link}
+      target="_blank"
+    >
+      {installWallet.name}
+      <div>{icon(installWallet.icon)}</div>
+    </a>
+  )}</div></div></Header_default>;
+};
+var InstallWallet_default = InstallWallet;
+
+// src/hooks/useModal.ts
+import { useContext } from "react";
+
+// src/components/ConnectContext.tsx
+import { createContext } from "react";
+var defaultContents = {
+  init: () => {
+  }
+};
+var ConnectContext = createContext(defaultContents);
+var ConnectContext_default = ConnectContext;
+
+// src/hooks/useModal.ts
+var useModal = () => {
+  const { modal } = useContext(ConnectContext_default);
+  return modal;
+};
+var useModal_default = useModal;
+
+// src/hooks/useWallet.ts
+import { useContext as useContext2 } from "react";
+
+// src/enums/EthosConnectStatus.ts
+var EthosConnectStatus = /* @__PURE__ */ ((EthosConnectStatus2) => {
+  EthosConnectStatus2["Loading"] = "loading";
+  EthosConnectStatus2["NoConnection"] = "no_connection";
+  EthosConnectStatus2["Connected"] = "connected";
+  return EthosConnectStatus2;
+})(EthosConnectStatus || {});
+
+// src/hooks/useWallet.ts
+var useWallet = () => {
+  const { wallet } = useContext2(ConnectContext_default);
+  return wallet ?? { status: "loading" /* Loading */, provider: null, setAltAccount: () => {
+  } };
+};
+var useWallet_default = useWallet;
+
+// src/hooks/useWindowDimensions.ts
+import { useState as useState2, useEffect as useEffect2 } from "react";
+function getWindowDimensions() {
+  if (typeof window === "undefined")
+    return { width: 0, height: 0 };
+  const { innerWidth: width, innerHeight: height } = window;
+  return {
+    width,
+    height
+  };
+}
+function useWindowDimensions() {
+  const [windowDimensions, setWindowDimensions] = useState2(
+    { width: 0, height: 0 }
+  );
+  useEffect2(() => {
+    setWindowDimensions(getWindowDimensions());
+    function handleResize() {
+      setWindowDimensions(getWindowDimensions());
+    }
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+  return windowDimensions;
+}
+
+// src/hooks/hooks.ts
+var hooks = {
+  useModal: useModal_default,
+  useWallet: useWallet_default,
+  useWindowDimensions
+};
+var hooks_default = hooks;
+
+// src/components/styled/MobileWallet.tsx
+var MobileWallet = () => {
+  return <div role="wallet-sign-in">
+    <span style={ethosWalletTitleText()}>Connect A Mobile Wallet</span>
+    <div style={walletExplanation()}><p>There are no mobile wallets yet on Sui.</p></div>
+  </div>;
+};
+var MobileWallet_default = MobileWallet;
+
+// src/components/styled/Or.tsx
+var Or = () => {
+  return <div style={strikeThroughOrContainer()}>
+    <div style={line()} />
+    {"or"}
+    <div style={line()} />
+  </div>;
+};
+var Or_default = Or;
+
+// src/components/styled/SignInModal.tsx
+function showSignInModal() {
+  window.ethosInternal.showSignInModal();
+}
+function hideSignInModal() {
+  window.ethosInternal.hideSignInModal();
+}
+var SignInModal = ({
+  connectMessage,
+  dappName,
+  dappIcon,
+  hideEmailSignIn,
+  hideWalletSignIn,
+  externalContext,
+  preferredWallets
+}) => {
+  const { wallets, selectWallet } = externalContext?.wallet || hooks_default.useWallet();
+  const { isModalOpen, openModal, closeModal } = externalContext?.modal || hooks_default.useModal();
+  const [isOpenAll, setIsOpenAll] = useState3(isModalOpen);
+  const [signingIn, setSigningIn] = useState3(false);
+  const [emailSent, setEmailSent] = useState3(false);
+  const { width } = hooks_default.useWindowDimensions();
+  const closeOnClickId = "ethos-close-on-click";
+  const [showEmail, setShowEmail] = useState3(false);
+  const [showMobile, setShowMobile] = useState3(false);
+  const [showInstallWallet, setShowInstallWallet] = useState3(false);
+  const [safeDappName, setSafeDappName] = useState3(dappName);
+  const [safeWallets, setSafeWallets] = useState3();
+  useHandleElementWithIdClicked(closeOnClickId, closeModal);
+  useEffect3(() => {
+    window.ethosInternal ||= {};
+    window.ethosInternal.showSignInModal = () => {
+      openModal();
+    };
+    window.ethosInternal.hideSignInModal = () => {
+      closeModal();
+    };
+    setIsOpenAll(isModalOpen);
+  }, [isModalOpen, setIsOpenAll, openModal, closeModal]);
+  useEffect3(() => {
+    if (hideEmailSignIn && hideWalletSignIn) {
+      throw new Error("hideEmailSignIn and hideWalletSignIn cannot both be true");
+    }
+  }, [hideEmailSignIn, hideWalletSignIn]);
+  useEffect3(() => {
+    if (!safeDappName) {
+      setSafeDappName(document.title);
+    }
+  }, [safeDappName]);
+  useEffect3(() => {
+    let safeWallets2 = wallets || [];
+    if (preferredWallets && preferredWallets.length > 0) {
+      safeWallets2 = safeWallets2.sort(
+        (a, b) => {
+          let aIndex = preferredWallets.indexOf(a.name);
+          if (aIndex === -1) {
+            aIndex = safeWallets2.length;
+          }
+          let bIndex = preferredWallets.indexOf(b.name);
+          if (bIndex === -1) {
+            bIndex = safeWallets2.length;
+          }
+          return aIndex - bIndex;
+        }
+      );
+    }
+    log_default("preferredWallets", preferredWallets, safeWallets2);
+    setSafeWallets(safeWallets2);
+  }, [wallets, preferredWallets, log_default]);
+  const _toggleInstallWallet = useCallback3(() => {
+    setShowInstallWallet((prev) => !prev);
+  }, []);
+  const _toggleEmail = useCallback3(() => {
+    setShowEmail((prev) => !prev);
+  }, []);
+  const _reset = useCallback3(() => {
+    setShowInstallWallet(false);
+    setShowMobile(false);
+    setShowEmail(false);
+  }, []);
+  const safeConnectMessage = useMemo2(() => {
+    if (connectMessage)
+      return connectMessage;
+    if (!safeDappName) {
+      return <></>;
+    }
+    return <>
+      {"Connect to "}
+      <span style={highlighted()}>{safeDappName}</span>
+    </>;
+  }, [safeDappName, connectMessage]);
+  const modalContent = useMemo2(() => {
+    if (!safeWallets) {
+      return <></>;
+    }
+    if (showMobile) {
+      return <MobileWallet_default />;
+    }
+    if (showInstallWallet || hideEmailSignIn && safeWallets.length === 0) {
+      return <InstallWallet_default width={width} />;
+    }
+    if (hideWalletSignIn) {
+      return <Email_default
+        setSigningIn={setSigningIn}
+        setEmailSent={setEmailSent}
+        width={width}
+      />;
+    }
+    if (!showEmail && safeWallets.length > 0)
+      return <Header_default
+        title={safeConnectMessage}
+        dappIcon={dappIcon}
+        subTitle="Choose from your installed wallets"
+      >
+        <Wallets_default
+          wallets={safeWallets}
+          selectWallet={selectWallet}
+          width={width}
+        />
+        {!hideEmailSignIn && <>
+          <Or_default />
+          <div style={submitButtonContainer()}><IconButton_default
+            text="Sign In With Email"
+            onClick={_toggleEmail}
+            width={width}
+            primary={true}
+          /></div>
+        </>}
+      </Header_default>;
+    return <Header_default
+      title={safeConnectMessage}
+      dappIcon={dappIcon}
+      subTitle={`Log in to ${safeDappName}`}
+    >
+      <Email_default
+        setSigningIn={setSigningIn}
+        setEmailSent={setEmailSent}
+        width={width}
+      />
+      {!hideWalletSignIn && <>
+        <Or_default />
+        <div style={submitButtonContainer()}>{safeWallets.length > 0 ? <IconButton_default
+          icon={<WalletsIcon_default />}
+          text="Select One Of Your Wallets"
+          onClick={_toggleEmail}
+          width={width}
+        /> : <IconButton_default
+          icon={<WalletsIcon_default />}
+          text="Install A Wallet"
+          onClick={_toggleInstallWallet}
+          width={width}
+        />}</div>
+      </>}
+    </Header_default>;
+  }, [safeConnectMessage, safeDappName, hideEmailSignIn, hideWalletSignIn, safeWallets, showEmail, showMobile, showInstallWallet]);
+  const subpage = useMemo2(() => {
+    return showMobile || showInstallWallet;
+  }, [showMobile, showInstallWallet]);
+  const loader = useMemo2(() => <div style={loaderStyle()}><Loader_default width={50} /></div>, []);
+  return <Dialog_default isOpenAll={isOpenAll}><ModalWrapper_default
+    closeOnClickId={closeOnClickId}
+    onClose={closeModal}
+    isOpenAll={isOpenAll}
+    width={width}
+    back={subpage ? _reset : null}
+  >{emailSent ? <EmailSent_default /> : signingIn ? loader : modalContent}</ModalWrapper_default></Dialog_default>;
+};
+var SignInModal_default = SignInModal;
+
+// src/hooks/useContext.ts
+import {
+  useCallback as useCallback6,
+  useEffect as useEffect7,
+  useMemo as useMemo4,
+  useState as useState6
+} from "react";
+
+// src/hooks/useAccount.ts
+import { useEffect as useEffect4, useRef, useState as useState4 } from "react";
+var useAccount = (signer, network) => {
+  const [altAccount, setAltAccount] = useState4();
+  const [account, setAccount] = useState4({});
+  const latestNetwork = useRef(network);
+  const existingContents = useRef();
+  useEffect4(() => {
+    if (!signer)
+      return;
+    latestNetwork.current = network;
+    const initAccount = async () => {
+      const address2 = altAccount?.address ?? signer.currentAccount?.address;
+      if (!address2) {
+        return;
+      }
+      setAccount((prev) => {
+        if (prev.address === address2)
+          return prev;
+        return { ...prev, address: address2 };
+      });
+      const contents = await getWalletContents_default({
+        address: address2,
+        network,
+        existingContents: existingContents.current
+      });
+      if (!contents || network !== latestNetwork.current || JSON.stringify(existingContents.current) === JSON.stringify(contents))
+        return;
+      existingContents.current = contents;
+      setAccount((prev) => ({ ...prev, contents }));
+    };
+    initAccount();
+    const interval = setInterval(initAccount, 5e3);
+    return () => clearInterval(interval);
+  }, [network, signer, altAccount]);
+  return { account, altAccount, setAltAccount };
+};
+var useAccount_default = useAccount;
+
+// src/hooks/useConnect.ts
+import { useCallback as useCallback5, useEffect as useEffect6, useRef as useRef3, useState as useState5 } from "react";
+
+// src/hooks/useWalletKit.ts
+import { useCallback as useCallback4, useEffect as useEffect5, useMemo as useMemo3, useRef as useRef2, useSyncExternalStore } from "react";
+import { createWalletKitCore } from "@mysten/wallet-kit-core";
+import { UnsafeBurnerWalletAdapter, WalletStandardAdapterProvider } from "@mysten/wallet-adapter-all-wallets";
+var useWalletKit = ({ defaultChain, configuredAdapters, features, enableUnsafeBurner, preferredWallets, storageAdapter, storageKey, disableAutoConnect }) => {
+  const adapters = useMemo3(
+    () => configuredAdapters ?? [
+      new WalletStandardAdapterProvider({ features }),
+      ...enableUnsafeBurner ? [new UnsafeBurnerWalletAdapter()] : []
+    ],
+    [configuredAdapters]
+  );
+  const walletKitRef = useRef2(null);
+  if (!walletKitRef.current) {
+    walletKitRef.current = createWalletKitCore({
+      adapters,
+      preferredWallets,
+      storageAdapter,
+      storageKey
+    });
+  }
+  const { wallets, status, currentWallet, accounts, currentAccount } = useSyncExternalStore(
+    walletKitRef.current.subscribe,
+    walletKitRef.current.getState,
+    walletKitRef.current.getState
+  );
+  useEffect5(() => {
+    if (!disableAutoConnect) {
+      walletKitRef.current?.autoconnect();
+    }
+  }, [status, wallets]);
+  const { autoconnect, ...walletFunctions } = walletKitRef.current;
+  const signAndExecuteTransactionBlock = useCallback4((input) => {
+    if (!currentWallet || !currentAccount) {
+      throw new Error("No wallet connect to sign message");
+    }
+    const account = input.account || currentAccount;
+    const chain = input.chain || defaultChain || DEFAULT_CHAIN;
+    return currentWallet.signAndExecuteTransactionBlock({
+      ...input,
+      account,
+      chain
+    });
+  }, [currentWallet, currentAccount, defaultChain]);
+  const signTransactionBlock = useCallback4((input) => {
+    if (!currentWallet || !currentAccount) {
+      throw new Error("No wallet connect to sign message");
+    }
+    const account = input.account || currentAccount;
+    const chain = input.chain || defaultChain || DEFAULT_CHAIN;
+    return currentWallet.signTransactionBlock({
+      ...input,
+      account,
+      chain
+    });
+  }, [currentWallet, currentAccount, defaultChain]);
+  const signMessage = useCallback4((input) => {
+    if (!currentWallet || !currentAccount) {
+      throw new Error("No wallet connect to sign message");
+    }
+    const account = input.account || currentAccount;
+    const message = typeof input.message === "string" ? new Uint8Array(Buffer.from(input.message, "utf8")) : input.message;
+    return currentWallet.signMessage({
+      ...input,
+      message,
+      account
+    });
+  }, [currentWallet, currentAccount]);
+  const requestPreapproval = useCallback4(async (preapproval) => {
+    if (!currentWallet || !currentAccount) {
+      throw new Error("No wallet connect to preapprove transactions");
+    }
+    const ethosWallet = window.ethosWallet;
+    if (!ethosWallet || currentWallet.name !== "Ethos Wallet") {
+      console.log("Wallet does not support preapproval");
+      return false;
+    }
+    if (!preapproval.address) {
+      preapproval.address = currentAccount.address;
+    }
+    if (!preapproval.chain) {
+      preapproval.chain = defaultChain ?? DEFAULT_CHAIN;
+    }
+    return ethosWallet.requestPreapproval(preapproval);
+  }, [currentWallet, currentAccount, defaultChain]);
+  const constructedSigner = useMemo3(() => {
+    if (!currentWallet || !currentAccount)
+      return null;
+    return {
+      type: "extension" /* Extension */,
+      name: currentWallet.name,
+      icon: currentWallet.name === "Sui Wallet" ? "https://sui.io/favicon.png" : currentWallet.icon,
+      getAddress: async () => currentAccount?.address,
+      accounts,
+      currentAccount,
+      signAndExecuteTransactionBlock,
+      signTransactionBlock,
+      requestPreapproval,
+      signMessage,
+      disconnect: () => {
+        currentWallet.disconnect();
+        walletKitRef.current?.disconnect();
+      }
+    };
+  }, [currentWallet, accounts, currentAccount, signAndExecuteTransactionBlock, requestPreapproval, signMessage]);
+  return {
+    wallets,
+    status,
+    signer: constructedSigner,
+    ...walletFunctions
+  };
+};
+var useWalletKit_default = useWalletKit;
+
+// src/hooks/useConnect.ts
+import { Connection as Connection2, JsonRpcProvider as JsonRpcProvider2 } from "@mysten/sui.js";
+import { WalletKitCoreConnectionStatus } from "@mysten/wallet-kit-core";
+var useConnect = (ethosConfiguration, onWalletConnected) => {
+  const signerFound = useRef3(false);
+  const methodsChecked = useRef3({
+    "ethos": false,
+    // 'mobile': false,
+    "extension": false
+  });
+  const [providerAndSigner, setProviderAndSigner] = useState5({
+    provider: null,
+    signer: null
+  });
+  const {
+    wallets,
+    status: suiStatus,
+    signer: suiSigner,
+    getState,
+    connect
+  } = useWalletKit_default({
+    defaultChain: ethosConfiguration?.chain ?? DEFAULT_CHAIN,
+    preferredWallets: ethosConfiguration?.preferredWallets,
+    disableAutoConnect: ethosConfiguration?.disableAutoConnect
+  });
+  const disconnect = useCallback5(() => {
+    signerFound.current = false;
+    methodsChecked.current = {
+      "ethos": false,
+      // 'mobile': false,
+      "extension": false
+    };
+    setProviderAndSigner((prev) => ({
+      ...prev,
+      signer: null
+    }));
+  }, []);
+  useEffect6(() => {
+    signerFound.current = false;
+    methodsChecked.current = {
+      "ethos": false,
+      // 'mobile': false,
+      "extension": false
+    };
+  }, [ethosConfiguration]);
+  useEffect6(() => {
+    const { provider, signer } = providerAndSigner;
+    if (!provider && !signer)
+      return;
+    const extensionState = getState();
+    if (extensionState.isConnecting || extensionState.isError)
+      return;
+    onWalletConnected && onWalletConnected(providerAndSigner);
+  }, [suiStatus, providerAndSigner, onWalletConnected, getState]);
+  const checkSigner = useCallback5((signer, type) => {
+    log_default("useConnect", "trying to set providerAndSigner", type, signerFound.current, methodsChecked.current);
+    if (signerFound.current)
+      return;
+    if (type) {
+      methodsChecked.current[type] = true;
+    }
+    const allMethodsChecked = !Object.values(methodsChecked.current).includes(false);
+    if (!signer && !allMethodsChecked)
+      return;
+    signerFound.current = !!signer;
+    const network = typeof ethosConfiguration?.network === "string" ? ethosConfiguration.network : DEFAULT_NETWORK;
+    const connection = new Connection2({ fullnode: network });
+    const provider = new JsonRpcProvider2(connection);
+    if (signer) {
+      const _disconnect = signer?.disconnect;
+      signer.disconnect = () => {
+        _disconnect();
+        disconnect();
+      };
+    }
+    setProviderAndSigner({ provider, signer });
+  }, [disconnect]);
+  useEffect6(() => {
+    if (suiStatus === WalletKitCoreConnectionStatus.DISCONNECTED) {
+      methodsChecked.current["extension"] = false;
+      signerFound.current = false;
+      setProviderAndSigner((prev) => ({
+        ...prev,
+        signer: null
+      }));
+    }
+  }, [suiStatus]);
+  useEffect6(() => {
+    if (!ethosConfiguration)
+      return;
+    log_default("mobile", "listening to mobile connection from EthosConnectProvider");
+  }, [checkSigner, ethosConfiguration]);
+  useEffect6(() => {
+    if (!ethosConfiguration)
+      return;
+    const state = getState();
+    log_default("useConnect", "Setting providerAndSigner extension", state);
+    if (state.isConnecting || state.isError)
+      return;
+    checkSigner(suiSigner, "extension");
+  }, [suiStatus, getState, checkSigner, suiSigner, ethosConfiguration]);
+  useEffect6(() => {
+    if (!ethosConfiguration)
+      return;
+    if (!ethosConfiguration.apiKey) {
+      log_default("useConnect", "Setting null providerAndSigner ethos");
+      checkSigner(null, "ethos");
+      return;
+    }
+    const fetchEthosSigner = async () => {
+      const signer = await lib_default.getEthosSigner({ defaultChain: ethosConfiguration.chain ?? DEFAULT_CHAIN });
+      log_default("useConnect", "Setting providerAndSigner ethos", signer);
+      checkSigner(signer, "ethos");
+    };
+    fetchEthosSigner();
+  }, [checkSigner, ethosConfiguration]);
+  return { wallets, providerAndSigner, connect, getState };
+};
+var useConnect_default = useConnect;
+
+// src/hooks/useContext.ts
+var DEFAULT_CONFIGURATION = {
+  network: DEFAULT_NETWORK,
+  chain: DEFAULT_CHAIN,
+  walletAppUrl: "https://ethoswallet.xyz"
+};
+var useContext3 = ({ configuration, onWalletConnected }) => {
+  const [ethosConfiguration, setEthosConfiguration] = useState6({
+    ...DEFAULT_CONFIGURATION,
+    ...configuration
+  });
+  const [isModalOpen, setIsModalOpen] = useState6(false);
+  const init = useCallback6((config) => {
+    log_default("EthosConnectProvider", "EthosConnectProvider Configuration:", config);
+    const fullConfiguration = {
+      ...DEFAULT_CONFIGURATION,
+      ...config
+    };
+    lib_default.initializeEthos(fullConfiguration);
+    setEthosConfiguration((prev) => {
+      if (JSON.stringify(fullConfiguration) !== JSON.stringify(prev)) {
+        return fullConfiguration;
+      } else {
+        return prev;
+      }
+    });
+  }, []);
+  useEffect7(() => {
+    lib_default.initializeEthos(ethosConfiguration);
+  }, [ethosConfiguration]);
+  useEffect7(() => {
+    if (!configuration)
+      return;
+    if (JSON.stringify(ethosConfiguration) === JSON.stringify(configuration))
+      return;
+    init(configuration);
+  }, [ethosConfiguration, configuration]);
+  const _onWalletConnected = useCallback6((providerAndSigner2) => {
+    setIsModalOpen(false);
+    onWalletConnected && onWalletConnected(providerAndSigner2);
+  }, [onWalletConnected]);
+  const {
+    wallets,
+    connect: selectWallet,
+    providerAndSigner,
+    getState
+  } = useConnect_default(ethosConfiguration, _onWalletConnected);
+  const {
+    account: { address: address2, contents },
+    altAccount,
+    setAltAccount
+  } = useAccount_default(providerAndSigner.signer, ethosConfiguration?.network ?? DEFAULT_NETWORK);
+  const modal = useMemo4(() => {
+    const openModal = () => {
+      setIsModalOpen(true);
+    };
+    const closeModal = () => {
+      setIsModalOpen(false);
+    };
+    return {
+      isModalOpen,
+      openModal,
+      closeModal
+    };
+  }, [isModalOpen, setIsModalOpen]);
+  const wallet = useMemo4(() => {
+    const { provider, signer } = providerAndSigner;
+    const extensionState = getState();
+    let status;
+    if (signer?.type === "hosted") {
+      status = "connected" /* Connected */;
+    } else if (extensionState.isConnecting) {
+      status = "loading" /* Loading */;
+    } else if (provider && extensionState.isConnected) {
+      status = "connected" /* Connected */;
+    } else {
+      status = "no_connection" /* NoConnection */;
+    }
+    const context = {
+      status,
+      wallets: wallets.map((w) => ({
+        ...w,
+        name: w.name,
+        icon: w.icon
+      })),
+      selectWallet,
+      provider,
+      altAccount,
+      setAltAccount
+    };
+    if (signer && address2) {
+      context.wallet = {
+        ...signer,
+        address: address2,
+        contents
+      };
+    }
+    return context;
+  }, [
+    wallets,
+    selectWallet,
+    address2,
+    altAccount,
+    setAltAccount,
+    providerAndSigner,
+    contents,
+    ethosConfiguration
+  ]);
+  useEffect7(() => {
+    if (isModalOpen) {
+      document.getElementsByTagName("html").item(0)?.setAttribute("style", "overflow: hidden;");
+    } else {
+      document.getElementsByTagName("html").item(0)?.setAttribute("style", "");
+    }
+  }, [isModalOpen]);
+  const value = useMemo4(() => ({
+    wallet,
+    modal,
+    providerAndSigner
+  }), [wallet, modal, providerAndSigner]);
+  return { ...value, ethosConfiguration, init };
+};
+var useContext_default = useContext3;
+
+// src/components/EthosConnectProvider.tsx
+var EthosConnectProvider = ({ ethosConfiguration, onWalletConnected, connectMessage, dappName, dappIcon, children }) => {
+  const context = useContext_default({ configuration: ethosConfiguration || {}, onWalletConnected });
+  return <ConnectContext_default.Provider value={context}>
+    {children}
+    <SignInModal_default
+      isOpen={context.modal?.isModalOpen || false}
+      hideEmailSignIn={context.ethosConfiguration?.hideEmailSignIn || false}
+      hideWalletSignIn={context.ethosConfiguration?.hideWalletSignIn || false}
+      connectMessage={connectMessage}
+      dappName={dappName}
+      dappIcon={dappIcon}
+      preferredWallets={ethosConfiguration?.preferredWallets}
+    />
+  </ConnectContext_default.Provider>;
+};
+var EthosConnectProvider_default = EthosConnectProvider;
+
+// src/components/styled/SignInButton.tsx
+import { useCallback as useCallback7 } from "react";
+
+// src/components/headless/WorkingButton.tsx
+var WorkingButton = (props) => {
+  const { children, isWorking, workingComponent, ...reactProps } = props;
+  return <button {...reactProps}>{isWorking ? workingComponent || <span className="block p-2"><Loader_default width={32} /></span> : <>{children}</>}</button>;
+};
+var WorkingButton_default = WorkingButton;
+
+// src/components/styled/SignInButton.tsx
+var SignInButton = (props) => {
+  const { children, onClick, externalContext, ...reactProps } = props;
+  const { openModal } = externalContext?.modal || useModal_default();
+  const _onClick = useCallback7((e) => {
+    openModal();
+    onClick && onClick(e);
+  }, [openModal, onClick]);
+  return <><WorkingButton_default onClick={_onClick} {...reactProps} style={buttonDefault(props.style)}>{children || <>Sign In</>}</WorkingButton_default></>;
+};
+var SignInButton_default = SignInButton;
+var buttonDefault = (providedStyles) => ({
+  lineHeight: "21px",
+  border: "none",
+  cursor: "pointer",
+  fontFamily: "inherit",
+  fontSize: "14px",
+  ...providedStyles || {}
+});
+
+// src/components/headless/HoverColorButton.tsx
+import { useCallback as useCallback8, useState as useState7 } from "react";
+var HoverColorButton = (props) => {
+  const { hoverBackgroundColor, hoverChildren, children, style, ...workingButtonProps } = props;
+  const [hover, setHover] = useState7(false);
+  const onMouseEnter = useCallback8(() => {
+    setHover(true);
+  }, []);
+  const onMouseLeave = useCallback8(() => {
+    setHover(false);
+  }, []);
+  return <WorkingButton_default
+    onMouseEnter={onMouseEnter}
+    onMouseLeave={onMouseLeave}
+    style={{
+      ...style,
+      backgroundColor: hover ? hoverBackgroundColor || primaryColor : void 0,
+      color: hover ? "white" : "black"
+    }}
+    {...workingButtonProps}
+  >{hover ? hoverChildren : children}</WorkingButton_default>;
+};
+var HoverColorButton_default = HoverColorButton;
+
+// src/components/styled/AddressWidget.tsx
+import { useCallback as useCallback12, useState as useState8 } from "react";
+
+// src/lib/truncateMiddle.ts
+var truncateMiddle = (text, length = 6) => text ? `${text.slice(0, length)}...${text.slice(length * -1)}` : "";
+var truncateMiddle_default = truncateMiddle;
+
+// src/components/svg/Sui.tsx
+var Sui = ({ width = 24, color = "#6EBCEE" }) => <svg
+  id="SuiSvg"
+  xmlns="http://www.w3.org/2000/svg"
+  width={width}
+  height={width * (40 / 28)}
+  viewBox="-1 0 28 40"
+  style={{ display: "block", verticalAlign: "middle" }}
+><path
+  d="M1.8611,33.0541a13.6477,13.6477,0,0,0,23.7778,0,13.89,13.89,0,0,0,0-13.8909L15.1824.8368a1.6444,1.6444,0,0,0-2.8648,0L1.8611,19.1632A13.89,13.89,0,0,0,1.8611,33.0541ZM10.8044,9.5555,13.0338,5.648a.8222.8222,0,0,1,1.4324,0L23.043,20.68a10.8426,10.8426,0,0,1,.8873,8.8828,9.4254,9.4254,0,0,0-.4388-1.4586c-1.1847-3.0254-3.8634-5.36-7.9633-6.9393-2.8187-1.0819-4.618-2.6731-5.3491-4.73C9.2375,13.7848,10.221,10.8942,10.8044,9.5555ZM7.0028,16.2184,4.457,20.68a10.8569,10.8569,0,0,0,0,10.8582,10.6776,10.6776,0,0,0,16.1566,2.935,7.5061,7.5061,0,0,0,.0667-5.2913c-.87-2.1858-2.9646-3.9308-6.2252-5.1876-3.6857-1.4147-6.08-3.6233-7.1157-6.5625A9.297,9.297,0,0,1,7.0028,16.2184Z"
+  style={{ fill: color, fillRule: "evenodd" }}
+/></svg>;
+var Sui_default = Sui;
+
+// src/components/styled/CopyWalletAddressButton.tsx
+import { useCallback as useCallback9 } from "react";
+
+// src/components/styled/MenuButton.tsx
+var MenuButton = (props) => {
+  return <HoverColorButton_default
+    {...props}
+    style={button()}
+  />;
+};
+var MenuButton_default = MenuButton;
+var button = () => ({
+  width: "100%",
+  borderRadius: "12px",
+  textAlign: "left",
+  padding: "6px 12px",
+  display: "flex",
+  alignItems: "center",
+  gap: "6px",
+  border: "none",
+  fontFamily: "inherit",
+  cursor: "pointer"
+});
+
+// src/components/styled/CopyWalletAddressButton.tsx
+var CopyWalletAddressButton = (props) => {
+  const { externalContext, ...buttonProps } = props;
+  const { wallet } = externalContext?.wallet || useWallet_default();
+  const children = useCallback9((hover) => <>
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path
+      d="M15.6657 3.88789C15.3991 2.94272 14.5305 2.25 13.5 2.25H10.5C9.46954 2.25 8.60087 2.94272 8.33426 3.88789M15.6657 3.88789C15.7206 4.0825 15.75 4.28782 15.75 4.5V4.5C15.75 4.91421 15.4142 5.25 15 5.25H9C8.58579 5.25 8.25 4.91421 8.25 4.5V4.5C8.25 4.28782 8.27937 4.0825 8.33426 3.88789M15.6657 3.88789C16.3119 3.93668 16.9545 3.99828 17.5933 4.07241C18.6939 4.20014 19.5 5.149 19.5 6.25699V19.5C19.5 20.7426 18.4926 21.75 17.25 21.75H6.75C5.50736 21.75 4.5 20.7426 4.5 19.5V6.25699C4.5 5.149 5.30608 4.20014 6.40668 4.07241C7.04547 3.99828 7.68808 3.93668 8.33426 3.88789"
+      stroke={hover ? "white" : "black"}
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    /></svg>
+    {"Copy Wallet Address"}
+  </>, []);
+  const onClick = useCallback9((e) => {
+    const element = e.target;
+    const innerHTML = element.innerHTML;
+    element.innerHTML = "Copied!";
+    navigator.clipboard.writeText(wallet?.address || "");
+    setTimeout(() => {
+      element.innerHTML = innerHTML;
+    }, 1e3);
+  }, [wallet]);
+  return <MenuButton_default
+    {...buttonProps}
+    onClick={onClick}
+    hoverChildren={children(true)}
+  >{children(false)}</MenuButton_default>;
+};
+var CopyWalletAddressButton_default = CopyWalletAddressButton;
+
+// src/components/styled/WalletExplorerButton.tsx
+import { useCallback as useCallback10 } from "react";
+var WalletExplorerButton = (props) => {
+  const children = useCallback10((hover) => <>
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path
+      d="M12 21C16.1926 21 19.7156 18.1332 20.7157 14.2529M12 21C7.80742 21 4.28442 18.1332 3.2843 14.2529M12 21C14.4853 21 16.5 16.9706 16.5 12C16.5 7.02944 14.4853 3 12 3M12 21C9.51472 21 7.5 16.9706 7.5 12C7.5 7.02944 9.51472 3 12 3M12 3C15.3652 3 18.299 4.84694 19.8431 7.58245M12 3C8.63481 3 5.70099 4.84694 4.15692 7.58245M19.8431 7.58245C17.7397 9.40039 14.9983 10.5 12 10.5C9.00172 10.5 6.26027 9.40039 4.15692 7.58245M19.8431 7.58245C20.5797 8.88743 21 10.3946 21 12C21 12.778 20.9013 13.5329 20.7157 14.2529M20.7157 14.2529C18.1334 15.6847 15.1619 16.5 12 16.5C8.8381 16.5 5.86662 15.6847 3.2843 14.2529M3.2843 14.2529C3.09871 13.5329 3 12.778 3 12C3 10.3946 3.42032 8.88743 4.15692 7.58245"
+      stroke={hover ? "white" : "black"}
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    /></svg>
+    {"Wallet Explorer"}
+  </>, []);
+  const onClick = useCallback10(() => {
+    window.open("https://ethoswallet.xyz/dashboard", "_blank");
+  }, []);
+  return <MenuButton_default
+    {...props}
+    onClick={onClick}
+    hoverChildren={children(true)}
+  >{children(false)}</MenuButton_default>;
+};
+var WalletExplorerButton_default = WalletExplorerButton;
+
+// src/components/styled/LogoutButton.tsx
+import { useCallback as useCallback11 } from "react";
+var LogoutButton = (props) => {
+  const { externalContext, ...buttonProps } = props;
+  const { wallet } = externalContext?.wallet || useWallet_default();
+  const children = useCallback11((hover) => <>
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path
+      d="M13.5 21V20.25V21ZM7.5 21V21.75V21ZM5.25 18.75H6H5.25ZM5.25 5.25H4.5H5.25ZM7.5 3V2.25V3ZM13.5 3V3.75V3ZM15.75 5.25L15 5.25V5.25H15.75ZM15 9C15 9.41421 15.3358 9.75 15.75 9.75C16.1642 9.75 16.5 9.41421 16.5 9H15ZM16.5 15C16.5 14.5858 16.1642 14.25 15.75 14.25C15.3358 14.25 15 14.5858 15 15H16.5ZM15.75 18.75H16.5H15.75ZM18.2197 14.4697C17.9268 14.7626 17.9268 15.2374 18.2197 15.5303C18.5126 15.8232 18.9874 15.8232 19.2803 15.5303L18.2197 14.4697ZM21.75 12L22.2803 12.5303C22.5732 12.2374 22.5732 11.7626 22.2803 11.4697L21.75 12ZM19.2803 8.46967C18.9874 8.17678 18.5126 8.17678 18.2197 8.46967C17.9268 8.76256 17.9268 9.23744 18.2197 9.53033L19.2803 8.46967ZM9 11.25C8.58579 11.25 8.25 11.5858 8.25 12C8.25 12.4142 8.58579 12.75 9 12.75V11.25ZM13.5 20.25H7.5V21.75H13.5V20.25ZM6 18.75L6 5.25H4.5L4.5 18.75H6ZM7.5 3.75L13.5 3.75V2.25L7.5 2.25V3.75ZM15 5.25V9H16.5V5.25H15ZM15 15V18.75H16.5V15H15ZM6 5.25C6 4.42157 6.67157 3.75 7.5 3.75V2.25C5.84315 2.25 4.5 3.59315 4.5 5.25H6ZM7.5 20.25C6.67157 20.25 6 19.5784 6 18.75H4.5C4.5 20.4069 5.84315 21.75 7.5 21.75V20.25ZM13.5 21.75C15.1569 21.75 16.5 20.4069 16.5 18.75H15C15 19.5784 14.3284 20.25 13.5 20.25V21.75ZM13.5 3.75C14.3284 3.75 15 4.42157 15 5.25L16.5 5.25C16.5 3.59315 15.1569 2.25 13.5 2.25V3.75ZM19.2803 15.5303L22.2803 12.5303L21.2197 11.4697L18.2197 14.4697L19.2803 15.5303ZM22.2803 11.4697L19.2803 8.46967L18.2197 9.53033L21.2197 12.5303L22.2803 11.4697ZM21.75 11.25L9 11.25V12.75L21.75 12.75V11.25Z"
+      fill={hover ? "white" : "black"}
+    /></svg>
+    {"Log Out"}
+  </>, []);
+  return <MenuButton_default
+    {...buttonProps}
+    onClick={wallet?.disconnect}
+    hoverChildren={children(true)}
+  >{children(false)}</MenuButton_default>;
+};
+var LogoutButton_default = LogoutButton;
+
+// src/components/styled/AddressWidget.tsx
+import { useEffect as useEffect8 } from "react";
+
+// src/enums/AddressWidgetButtons.ts
+var AddressWidgetButtons = /* @__PURE__ */ ((AddressWidgetButtons2) => {
+  AddressWidgetButtons2["CopyWalletAddress"] = "copy_wallet_address";
+  AddressWidgetButtons2["WalletExplorer"] = "wallet_explorer";
+  AddressWidgetButtons2["Logout"] = "logout";
+  return AddressWidgetButtons2;
+})(AddressWidgetButtons || {});
+
+// src/components/styled/AddressWidget.tsx
+var AddressWidget = ({
+  includeMenu = true,
+  buttonColor = primaryColor,
+  extraButtons = [],
+  excludeButtons = [],
+  externalContext
+}) => {
+  const { wallet } = externalContext?.wallet || useWallet_default();
+  const [showMenu, setShowMenu] = useState8(false);
+  useEffect8(() => {
+    if (!wallet) {
+      setShowMenu(false);
+    }
+  }, [wallet]);
+  const onMouseEnter = useCallback12(() => {
+    if (!wallet)
+      return;
+    setShowMenu(true);
+  }, [wallet]);
+  const onMouseLeave = useCallback12(() => {
+    if (!wallet)
+      return;
+    setShowMenu(false);
+  }, [wallet]);
+  return <div style={container()} onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
+    <div style={primary()}>
+      <div><Sui_default color="#222532" width={12} /></div>
+      {wallet ? <>
+        <div style={sui()}>
+          {formatBalance(wallet.contents?.suiBalance)}
+          {" "}
+          {"Sui"}
+        </div>
+        <div style={address()}>
+          {wallet.icon && <img
+            style={walletIcon()}
+            src={wallet.icon}
+          />}
+          {truncateMiddle_default(wallet.address)}
+        </div>
+      </> : <SignInButton_default style={signIn()} externalContext={externalContext} />}
+    </div>
+    {includeMenu && showMenu && <div style={menu()}>
+      {!excludeButtons.includes("copy_wallet_address" /* CopyWalletAddress */) && <CopyWalletAddressButton_default
+        externalContext={externalContext}
+        hoverBackgroundColor={buttonColor}
+      />}
+      {!excludeButtons.includes("wallet_explorer" /* WalletExplorer */) && <WalletExplorerButton_default
+        hoverBackgroundColor={buttonColor}
+      />}
+      {extraButtons}
+      {!excludeButtons.includes("logout" /* Logout */) && <LogoutButton_default
+        externalContext={externalContext}
+        hoverBackgroundColor={buttonColor}
+      />}
+    </div>}
+  </div>;
+};
+var AddressWidget_default = AddressWidget;
+var container = () => ({
+  position: "relative",
+  backgroundColor: "white",
+  padding: "6px 12px 6px 18px",
+  boxShadow: "1px 1px 3px 1px #dfdfe0",
+  borderRadius: "18px",
+  fontSize: "14px",
+  color: "black"
+});
+var primary = () => ({
+  display: "flex",
+  justifyContent: "center",
+  alignItems: "center",
+  gap: "12px"
+});
+var sui = () => ({
+  whiteSpace: "nowrap"
+});
+var address = () => ({
+  borderRadius: "30px",
+  backgroundColor: "#f2f1f0",
+  padding: "6px 12px",
+  display: "flex",
+  alignItems: "center",
+  gap: "6px"
+});
+var menu = () => ({
+  display: "flex",
+  flexDirection: "column",
+  gap: "6px",
+  padding: "12px 18px",
+  position: "absolute",
+  bottom: 0,
+  left: "12px",
+  right: "12px",
+  transform: "translateY(100%)",
+  boxShadow: "1px 1px 3px 1px #dfdfe0",
+  borderBottomLeftRadius: "18px",
+  borderBottomRightRadius: "18px",
+  backgroundColor: "white",
+  zIndex: "99"
+});
+var signIn = () => ({
+  padding: "0 12px 0 0",
+  background: "none",
+  whiteSpace: "nowrap"
+});
+var walletIcon = () => ({
+  width: "20px",
+  height: "20px"
+});
+
+// src/lib/logout.ts
+var logout = async (signer, fromWallet = false) => {
+  log_default("logout", `-- Wallet ${fromWallet} --`, `-- Is Extension: ${signer?.type} --`, `-- Disconnect: ${!!signer?.disconnect} --`, "signer", signer);
+  if (signer.type === "extension" || !fromWallet) {
+    await signer.disconnect();
+  } else {
+    await signer.logout();
+  }
+};
+var logout_default = logout;
+
+// src/lib/preapprove.ts
+var preapprove = async ({ signer, preapproval }) => {
+  return signer.requestPreapproval(preapproval);
+};
+var preapprove_default = preapprove;
+
+// src/lib/sign.ts
+var sign = async ({ signer, message }) => {
+  return signer.sign({ message });
+};
+var sign_default = sign;
+
+// src/lib/transact.ts
+var transact = async ({
+  signer,
+  transactionInput
+}) => {
+  log_default("transact", "Starting transaction", signer, transactionInput);
+  return signer.signAndExecuteTransactionBlock(transactionInput);
+};
+var transact_default = transact;
+
+// src/lib/hideWallet.ts
+var hideWallet = (signer) => {
+  if (signer.type === "extension" /* Extension */)
+    return;
+  getIframe_default(false);
+};
+var hideWallet_default = hideWallet;
+
+// src/lib/showWallet.ts
+var showWallet = (signer) => {
+  if (signer.type === "extension" /* Extension */)
+    return;
+  getIframe_default(true);
+};
+var showWallet_default = showWallet;
+
+// src/lib/dripSui.ts
+import { Connection as Connection3, JsonRpcProvider as JsonRpcProvider3 } from "@mysten/sui.js";
+var dripSui = async ({ address: address2, network, faucet }) => {
+  const connection = new Connection3({ fullnode: network ?? DEFAULT_NETWORK, faucet: `${faucet ?? DEFAULT_FAUCET}gas` });
+  const provider = new JsonRpcProvider3(connection);
+  return provider.requestSuiFromFaucet(address2);
+};
+var dripSui_default = dripSui;
+
+// src/lib/nameService.ts
+import _2 from "lodash";
+import { Connection as Connection4, JsonRpcProvider as JsonRpcProvider4, TransactionBlock } from "@mysten/sui.js";
+var PACKAGE_ADDRESS = "0xe7ed73e4c2c1b38729155bf5c44dc4496a9edd2f";
+var REGISTRY_ADDRESS = "0xa378adb13792599e8eb8c7e4f2e938863921e4f4";
+var SENDER = "0x0000000000000000000000000000000000000002";
+var DEV_INSPECT_RESULT_PATH_0 = "results.Ok[0][1].returnValues[0][0]";
+var DEV_INSPECT_RESULT_PATH_1 = "results.Ok[0][1].returnValues[1][0]";
+var toHexString = (byteArray) => byteArray?.length > 0 ? Array.from(byteArray, (byte) => ("0" + (byte & 255).toString(16)).slice(-2)).join("") : "";
+var toString = (byteArray) => byteArray?.length > 0 ? new TextDecoder().decode(Buffer.from(byteArray.slice(1)).buffer) : "";
+var trimAddress = (address2) => String(address2?.match(/0x0{0,}([\w\d]+)/)?.[1]);
+var toFullAddress = (trimmedAddress) => trimmedAddress ? `0x${trimmedAddress.padStart(40, "0")}` : "";
+var getSuiName = async (address2, network, sender = SENDER) => {
+  const connection = new Connection4({ fullnode: network || DEFAULT_NETWORK });
+  const suiProvider = new JsonRpcProvider4(connection);
+  try {
+    const registryTx = new TransactionBlock();
+    registryTx.add(
+      TransactionBlock.Transactions.MoveCall({
+        target: `${PACKAGE_ADDRESS}::base_registry::get_record_by_key`,
+        arguments: [
+          registryTx.object(REGISTRY_ADDRESS),
+          registryTx.pure(`${trimAddress(address2)}.addr.reverse`)
+        ]
+      })
+    );
+    const resolverBytes = _2.get(
+      await suiProvider.devInspectTransactionBlock({
+        transactionBlock: registryTx,
+        sender
+      }),
+      DEV_INSPECT_RESULT_PATH_1
+    );
+    if (!resolverBytes)
+      return address2;
+    const resolver = toFullAddress(toHexString(resolverBytes));
+    const resolverTx = new TransactionBlock();
+    resolverTx.add(
+      TransactionBlock.Transactions.MoveCall({
+        target: `${PACKAGE_ADDRESS}::resolver::name`,
+        arguments: [
+          registryTx.object(resolver),
+          registryTx.pure(address2)
+        ]
+      })
+    );
+    const resolverResponse = await suiProvider.devInspectTransactionBlock({
+      transactionBlock: resolverTx,
+      sender
+    });
+    const nameByteArray = _2.get(resolverResponse, DEV_INSPECT_RESULT_PATH_0);
+    if (!nameByteArray)
+      return address2;
+    const name = toString(nameByteArray);
+    return name;
+  } catch (e) {
+    console.log("Error retreiving SuiNS Name", e);
+    return address2;
+  }
+};
+var getSuiAddress = async (domain, network, sender = SENDER) => {
+  const connection = new Connection4({ fullnode: network || DEFAULT_NETWORK });
+  const suiProvider = new JsonRpcProvider4(connection);
+  try {
+    const registryTx = new TransactionBlock();
+    registryTx.add(
+      TransactionBlock.Transactions.MoveCall({
+        target: `${PACKAGE_ADDRESS}::base_registry::get_record_by_key`,
+        arguments: [
+          registryTx.object(REGISTRY_ADDRESS),
+          registryTx.pure(domain)
+        ]
+      })
+    );
+    const resolverResponse = await suiProvider.devInspectTransactionBlock({
+      transactionBlock: registryTx,
+      sender
+    });
+    const resolverBytes = _2.get(resolverResponse, DEV_INSPECT_RESULT_PATH_1);
+    if (!resolverBytes)
+      return domain;
+    const resolver = toFullAddress(toHexString(resolverBytes));
+    const resolverTx = new TransactionBlock();
+    resolverTx.add(
+      TransactionBlock.Transactions.MoveCall({
+        target: `${PACKAGE_ADDRESS}::resolver::addr`,
+        arguments: [
+          registryTx.object(resolver),
+          registryTx.pure(domain)
+        ]
+      })
+    );
+    const resolverResponse2 = await suiProvider.devInspectTransactionBlock({
+      transactionBlock: resolverTx,
+      sender
+    });
+    const addr = _2.get(resolverResponse2, DEV_INSPECT_RESULT_PATH_0);
+    if (!addr)
+      return domain;
+    return toFullAddress(toHexString(addr));
+  } catch (e) {
+    console.log("Error retrieving address from SuiNS name", e);
+    return domain;
+  }
+};
+
+// src/hooks/useProviderAndSigner.ts
+import { useContext as useContext4 } from "react";
+var useProviderAndSigner = () => {
+  const { providerAndSigner } = useContext4(ConnectContext_default);
+  return providerAndSigner || { provider: null, signer: null };
+};
+var useProviderAndSigner_default = useProviderAndSigner;
+
+// src/hooks/useAddress.ts
+var useAddress = () => {
+  const { signer } = useProviderAndSigner_default();
+  return signer?.currentAccount?.address;
+};
+var useAddress_default = useAddress;
+
+// src/hooks/useContents.ts
+import { useContext as useContext5 } from "react";
+var useContents = () => {
+  const contents = useContext5(ConnectContext_default).wallet?.wallet?.contents;
+  return contents;
+};
+var useContents_default = useContents;
+
+// src/components/DetachedEthosConnectProvider.tsx
+var DetachedEthosConnectProvider = ({ context, connectMessage, dappName, dappIcon, children }) => {
+  return <>
+    {children}
+    <SignInModal_default
+      isOpen={context.modal.isModalOpen}
+      hideEmailSignIn={context.ethosConfiguration?.hideEmailSignIn || false}
+      hideWalletSignIn={context.ethosConfiguration?.hideWalletSignIn || false}
+      connectMessage={connectMessage}
+      dappName={dappName}
+      dappIcon={dappIcon}
+      externalContext={context}
+    />
+  </>;
+};
+var DetachedEthosConnectProvider_default = DetachedEthosConnectProvider;
+
+// src/index.ts
+var components = {
+  AddressWidget: AddressWidget_default,
+  MenuButton: MenuButton_default,
+  headless: {
+    HoverColorButton: HoverColorButton_default
+  }
+};
+var enums = {
+  AddressWidgetButtons
+};
+var ethos = {
+  login: login_default,
+  logout: logout_default,
+  sign: sign_default,
+  transact: transact_default,
+  preapprove: preapprove_default,
+  showWallet: showWallet_default,
+  hideWallet: hideWallet_default,
+  showSignInModal,
+  hideSignInModal,
+  useProviderAndSigner: useProviderAndSigner_default,
+  useAddress: useAddress_default,
+  useContents: useContents_default,
+  useWallet: useWallet_default,
+  useContext: useContext_default,
+  getWalletContents: getWalletContents_default,
+  dripSui: dripSui_default,
+  getSuiName,
+  getSuiAddress,
+  formatBalance,
+  truncateMiddle: truncateMiddle_default,
+  ipfsConversion,
+  components,
+  enums
+};
+export {
+  Chain,
+  DetachedEthosConnectProvider_default as DetachedEthosConnectProvider,
+  EthosConnectProvider_default as EthosConnectProvider,
+  EthosConnectStatus,
+  IntentScope,
+  SignInButton_default as SignInButton,
+  TransactionBlock2 as TransactionBlock,
+  ethos,
+  verifyMessage
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -317,6 +317,116 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@esbuild/android-arm64@0.17.17":
+  version "0.17.17"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.17.17.tgz#164b054d58551f8856285f386e1a8f45d9ba3a31"
+  integrity sha512-jaJ5IlmaDLFPNttv0ofcwy/cfeY4bh/n705Tgh+eLObbGtQBK3EPAu+CzL95JVE4nFAliyrnEu0d32Q5foavqg==
+
+"@esbuild/android-arm@0.17.17":
+  version "0.17.17"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.17.17.tgz#1b3b5a702a69b88deef342a7a80df4c894e4f065"
+  integrity sha512-E6VAZwN7diCa3labs0GYvhEPL2M94WLF8A+czO8hfjREXxba8Ng7nM5VxV+9ihNXIY1iQO1XxUU4P7hbqbICxg==
+
+"@esbuild/android-x64@0.17.17":
+  version "0.17.17"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.17.17.tgz#6781527e3c4ea4de532b149d18a2167f06783e7f"
+  integrity sha512-446zpfJ3nioMC7ASvJB1pszHVskkw4u/9Eu8s5yvvsSDTzYh4p4ZIRj0DznSl3FBF0Z/mZfrKXTtt0QCoFmoHA==
+
+"@esbuild/darwin-arm64@0.17.17":
+  version "0.17.17"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.17.17.tgz#c5961ef4d3c1cc80dafe905cc145b5a71d2ac196"
+  integrity sha512-m/gwyiBwH3jqfUabtq3GH31otL/0sE0l34XKpSIqR7NjQ/XHQ3lpmQHLHbG8AHTGCw8Ao059GvV08MS0bhFIJQ==
+
+"@esbuild/darwin-x64@0.17.17":
+  version "0.17.17"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.17.17.tgz#b81f3259cc349691f67ae30f7b333a53899b3c20"
+  integrity sha512-4utIrsX9IykrqYaXR8ob9Ha2hAY2qLc6ohJ8c0CN1DR8yWeMrTgYFjgdeQ9LIoTOfLetXjuCu5TRPHT9yKYJVg==
+
+"@esbuild/freebsd-arm64@0.17.17":
+  version "0.17.17"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.17.tgz#db846ad16cf916fd3acdda79b85ea867cb100e87"
+  integrity sha512-4PxjQII/9ppOrpEwzQ1b0pXCsFLqy77i0GaHodrmzH9zq2/NEhHMAMJkJ635Ns4fyJPFOlHMz4AsklIyRqFZWA==
+
+"@esbuild/freebsd-x64@0.17.17":
+  version "0.17.17"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.17.17.tgz#4dd99acbaaba00949d509e7c144b1b6ef9e1815b"
+  integrity sha512-lQRS+4sW5S3P1sv0z2Ym807qMDfkmdhUYX30GRBURtLTrJOPDpoU0kI6pVz1hz3U0+YQ0tXGS9YWveQjUewAJw==
+
+"@esbuild/linux-arm64@0.17.17":
+  version "0.17.17"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.17.17.tgz#7f9274140b2bb9f4230dbbfdf5dc2761215e30f6"
+  integrity sha512-2+pwLx0whKY1/Vqt8lyzStyda1v0qjJ5INWIe+d8+1onqQxHLLi3yr5bAa4gvbzhZqBztifYEu8hh1La5+7sUw==
+
+"@esbuild/linux-arm@0.17.17":
+  version "0.17.17"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.17.17.tgz#5c8e44c2af056bb2147cf9ad13840220bcb8948b"
+  integrity sha512-biDs7bjGdOdcmIk6xU426VgdRUpGg39Yz6sT9Xp23aq+IEHDb/u5cbmu/pAANpDB4rZpY/2USPhCA+w9t3roQg==
+
+"@esbuild/linux-ia32@0.17.17":
+  version "0.17.17"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.17.17.tgz#18a6b3798658be7f46e9873fa0c8d4bec54c9212"
+  integrity sha512-IBTTv8X60dYo6P2t23sSUYym8fGfMAiuv7PzJ+0LcdAndZRzvke+wTVxJeCq4WgjppkOpndL04gMZIFvwoU34Q==
+
+"@esbuild/linux-loong64@0.17.17":
+  version "0.17.17"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.17.17.tgz#a8d93514a47f7b4232716c9f02aeb630bae24c40"
+  integrity sha512-WVMBtcDpATjaGfWfp6u9dANIqmU9r37SY8wgAivuKmgKHE+bWSuv0qXEFt/p3qXQYxJIGXQQv6hHcm7iWhWjiw==
+
+"@esbuild/linux-mips64el@0.17.17":
+  version "0.17.17"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.17.17.tgz#4784efb1c3f0eac8133695fa89253d558149ee1b"
+  integrity sha512-2kYCGh8589ZYnY031FgMLy0kmE4VoGdvfJkxLdxP4HJvWNXpyLhjOvxVsYjYZ6awqY4bgLR9tpdYyStgZZhi2A==
+
+"@esbuild/linux-ppc64@0.17.17":
+  version "0.17.17"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.17.17.tgz#ef6558ec5e5dd9dc16886343e0ccdb0699d70d3c"
+  integrity sha512-KIdG5jdAEeAKogfyMTcszRxy3OPbZhq0PPsW4iKKcdlbk3YE4miKznxV2YOSmiK/hfOZ+lqHri3v8eecT2ATwQ==
+
+"@esbuild/linux-riscv64@0.17.17":
+  version "0.17.17"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.17.17.tgz#13a87fdbcb462c46809c9d16bcf79817ecf9ce6f"
+  integrity sha512-Cj6uWLBR5LWhcD/2Lkfg2NrkVsNb2sFM5aVEfumKB2vYetkA/9Uyc1jVoxLZ0a38sUhFk4JOVKH0aVdPbjZQeA==
+
+"@esbuild/linux-s390x@0.17.17":
+  version "0.17.17"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.17.17.tgz#83cb16d1d3ac0dca803b3f031ba3dc13f1ec7ade"
+  integrity sha512-lK+SffWIr0XsFf7E0srBjhpkdFVJf3HEgXCwzkm69kNbRar8MhezFpkIwpk0qo2IOQL4JE4mJPJI8AbRPLbuOQ==
+
+"@esbuild/linux-x64@0.17.17":
+  version "0.17.17"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.17.17.tgz#7bc400568690b688e20a0c94b2faabdd89ae1a79"
+  integrity sha512-XcSGTQcWFQS2jx3lZtQi7cQmDYLrpLRyz1Ns1DzZCtn898cWfm5Icx/DEWNcTU+T+tyPV89RQtDnI7qL2PObPg==
+
+"@esbuild/netbsd-x64@0.17.17":
+  version "0.17.17"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.17.17.tgz#1b5dcfbc4bfba80e67a11e9148de836af5b58b6c"
+  integrity sha512-RNLCDmLP5kCWAJR+ItLM3cHxzXRTe4N00TQyQiimq+lyqVqZWGPAvcyfUBM0isE79eEZhIuGN09rAz8EL5KdLA==
+
+"@esbuild/openbsd-x64@0.17.17":
+  version "0.17.17"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.17.17.tgz#e275098902291149a5dcd012c9ea0796d6b7adff"
+  integrity sha512-PAXswI5+cQq3Pann7FNdcpSUrhrql3wKjj3gVkmuz6OHhqqYxKvi6GgRBoaHjaG22HV/ZZEgF9TlS+9ftHVigA==
+
+"@esbuild/sunos-x64@0.17.17":
+  version "0.17.17"
+  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.17.17.tgz#10603474866f64986c0370a2d4fe5a2bb7fee4f5"
+  integrity sha512-V63egsWKnx/4V0FMYkr9NXWrKTB5qFftKGKuZKFIrAkO/7EWLFnbBZNM1CvJ6Sis+XBdPws2YQSHF1Gqf1oj/Q==
+
+"@esbuild/win32-arm64@0.17.17":
+  version "0.17.17"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.17.17.tgz#521a6d97ee0f96b7c435930353cc4e93078f0b54"
+  integrity sha512-YtUXLdVnd6YBSYlZODjWzH+KzbaubV0YVd6UxSfoFfa5PtNJNaW+1i+Hcmjpg2nEe0YXUCNF5bkKy1NnBv1y7Q==
+
+"@esbuild/win32-ia32@0.17.17":
+  version "0.17.17"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.17.17.tgz#56f88462ebe82dad829dc2303175c0e0ccd8e38e"
+  integrity sha512-yczSLRbDdReCO74Yfc5tKG0izzm+lPMYyO1fFTcn0QNwnKmc3K+HdxZWLGKg4pZVte7XVgcFku7TIZNbWEJdeQ==
+
+"@esbuild/win32-x64@0.17.17":
+  version "0.17.17"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.17.17.tgz#2b577b976e6844106715bbe0cdc57cd1528063f9"
+  integrity sha512-FNZw7H3aqhF9OyRQbDDnzUApDXfC1N6fgBhkqEO2jvYCJ+DxMTfZVqg3AX0R1khg1wHTBRD5SdcibSJ+XF6bFg==
+
 "@eslint-community/eslint-utils@^4.2.0":
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz#a23514e8fb9af1269d5f7788aa556798d61c6b59"
@@ -1478,6 +1588,11 @@ ansi-styles@^5.0.0:
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
   integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
 
+any-promise@^1.0.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/any-promise/-/any-promise-1.3.0.tgz#abc6afeedcea52e809cdc0376aed3ce39635d17f"
+  integrity sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==
+
 anymatch@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-2.0.0.tgz#bcb24b4f37934d9aa7ac17b4adaf89e7c76ef2eb"
@@ -1533,6 +1648,11 @@ arr-union@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
   integrity sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==
+
+array-union@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
+  integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
 
 array-unique@^0.3.2:
   version "0.3.2"
@@ -1746,6 +1866,18 @@ bufferutil@^4.0.1:
   dependencies:
     node-gyp-build "^4.3.0"
 
+bundle-require@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/bundle-require/-/bundle-require-4.0.1.tgz#2cc1ad76428043d15e0e7f30990ee3d5404aa2e3"
+  integrity sha512-9NQkRHlNdNpDBGmLpngF3EFDcwodhMUuLz9PaWYciVcQF9SE4LFjM2DB/xV1Li5JiuDMv7ZUWuC3rGbqR0MAXQ==
+  dependencies:
+    load-tsconfig "^0.2.3"
+
+cac@^6.7.12:
+  version "6.7.14"
+  resolved "https://registry.yarnpkg.com/cac/-/cac-6.7.14.tgz#804e1e6f506ee363cb0e3ccbb09cad5dd9870959"
+  integrity sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==
+
 cache-base@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/cache-base/-/cache-base-1.0.1.tgz#0a7f46416831c8b662ee36fe4e7c59d76f666ab2"
@@ -1839,7 +1971,7 @@ chardet@^0.7.0:
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
 
-chokidar@^3.4.2:
+chokidar@^3.4.2, chokidar@^3.5.1:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
   integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==
@@ -1973,6 +2105,11 @@ commander@^2.20.3:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
+commander@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
+  integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
+
 component-emitter@^1.2.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
@@ -2061,7 +2198,7 @@ data-urls@^3.0.1:
     whatwg-mimetype "^3.0.0"
     whatwg-url "^11.0.0"
 
-debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.3:
+debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.3:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
@@ -2169,6 +2306,13 @@ dijkstrajs@^1.0.1:
   resolved "https://registry.yarnpkg.com/dijkstrajs/-/dijkstrajs-1.0.2.tgz#2e48c0d3b825462afe75ab4ad5e829c8ece36257"
   integrity sha512-QV6PMaHTCNmKSeP6QoXhVTw9snc9VD8MulTT0Bd99Pacp4SS1cjcrYPgBPmibqKVtMJJfqC6XvOXgPMEEPH/fg==
 
+dir-glob@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-3.0.1.tgz#56dbf73d992a4a93ba1584f4534063fd2e41717f"
+  integrity sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==
+  dependencies:
+    path-type "^4.0.0"
+
 doctrine@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-3.0.0.tgz#addebead72a6574db783639dc87a121773973961"
@@ -2245,6 +2389,34 @@ esbuild@^0.11.18:
   version "0.11.23"
   resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.11.23.tgz#c42534f632e165120671d64db67883634333b4b8"
   integrity sha512-iaiZZ9vUF5wJV8ob1tl+5aJTrwDczlvGP0JoMmnpC2B0ppiMCu8n8gmy5ZTGl5bcG081XBVn+U+jP+mPFm5T5Q==
+
+esbuild@^0.17.6:
+  version "0.17.17"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.17.17.tgz#fa906ab11b11d2ed4700f494f4f764229b25c916"
+  integrity sha512-/jUywtAymR8jR4qsa2RujlAF7Krpt5VWi72Q2yuLD4e/hvtNcFQ0I1j8m/bxq238pf3/0KO5yuXNpuLx8BE1KA==
+  optionalDependencies:
+    "@esbuild/android-arm" "0.17.17"
+    "@esbuild/android-arm64" "0.17.17"
+    "@esbuild/android-x64" "0.17.17"
+    "@esbuild/darwin-arm64" "0.17.17"
+    "@esbuild/darwin-x64" "0.17.17"
+    "@esbuild/freebsd-arm64" "0.17.17"
+    "@esbuild/freebsd-x64" "0.17.17"
+    "@esbuild/linux-arm" "0.17.17"
+    "@esbuild/linux-arm64" "0.17.17"
+    "@esbuild/linux-ia32" "0.17.17"
+    "@esbuild/linux-loong64" "0.17.17"
+    "@esbuild/linux-mips64el" "0.17.17"
+    "@esbuild/linux-ppc64" "0.17.17"
+    "@esbuild/linux-riscv64" "0.17.17"
+    "@esbuild/linux-s390x" "0.17.17"
+    "@esbuild/linux-x64" "0.17.17"
+    "@esbuild/netbsd-x64" "0.17.17"
+    "@esbuild/openbsd-x64" "0.17.17"
+    "@esbuild/sunos-x64" "0.17.17"
+    "@esbuild/win32-arm64" "0.17.17"
+    "@esbuild/win32-ia32" "0.17.17"
+    "@esbuild/win32-x64" "0.17.17"
 
 escalade@^3.1.1:
   version "3.1.1"
@@ -2573,7 +2745,7 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
-fast-glob@^3.2.11:
+fast-glob@^3.2.11, fast-glob@^3.2.9:
   version "3.2.12"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.12.tgz#7f39ec99c2e6ab030337142da9e0c18f37afae80"
   integrity sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==
@@ -2766,6 +2938,18 @@ glob-parent@^6.0.2:
   dependencies:
     is-glob "^4.0.3"
 
+glob@7.1.6:
+  version "7.1.6"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
+  integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
 glob@^7.1.3, glob@^7.1.4:
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
@@ -2789,6 +2973,18 @@ globals@^13.19.0:
   integrity sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==
   dependencies:
     type-fest "^0.20.2"
+
+globby@^11.0.3:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-11.1.0.tgz#bd4be98bb042f83d796f7e3811991fbe82a0d34b"
+  integrity sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==
+  dependencies:
+    array-union "^2.1.0"
+    dir-glob "^3.0.1"
+    fast-glob "^3.2.9"
+    ignore "^5.2.0"
+    merge2 "^1.4.1"
+    slash "^3.0.0"
 
 gopd@^1.0.1:
   version "1.0.1"
@@ -3850,6 +4046,11 @@ jest@^28.1.1:
     import-local "^3.0.2"
     jest-cli "^28.1.3"
 
+joycon@^3.0.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/joycon/-/joycon-3.1.1.tgz#bce8596d6ae808f8b68168f5fc69280996894f03"
+  integrity sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==
+
 js-levenshtein@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/js-levenshtein/-/js-levenshtein-1.1.6.tgz#c6cee58eb3550372df8deb85fad5ce66ce01d59d"
@@ -4008,10 +4209,20 @@ levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
+lilconfig@^2.0.5:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/lilconfig/-/lilconfig-2.1.0.tgz#78e23ac89ebb7e1bfbf25b18043de756548e7f52"
+  integrity sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==
+
 lines-and-columns@^1.1.6:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
+
+load-tsconfig@^0.2.3:
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/load-tsconfig/-/load-tsconfig-0.2.5.tgz#453b8cd8961bfb912dea77eb6c168fe8cca3d3a1"
+  integrity sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==
 
 locate-path@^5.0.0:
   version "5.0.0"
@@ -4031,6 +4242,11 @@ lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
+
+lodash.sortby@^4.7.0:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
+  integrity sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==
 
 lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.21:
   version "4.17.21"
@@ -4095,7 +4311,7 @@ merge-stream@^2.0.0:
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
   integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
 
-merge2@^1.3.0:
+merge2@^1.3.0, merge2@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
@@ -4214,6 +4430,15 @@ mute-stream@0.0.8:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
 
+mz@^2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/mz/-/mz-2.7.0.tgz#95008057a56cafadc2bc63dde7f9ff6955948e32"
+  integrity sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==
+  dependencies:
+    any-promise "^1.0.0"
+    object-assign "^4.0.1"
+    thenify-all "^1.0.0"
+
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
@@ -4311,7 +4536,7 @@ nwsapi@^2.2.0:
   resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.2.tgz#e5418863e7905df67d51ec95938d67bf801f0bb0"
   integrity sha512-90yv+6538zuvUMnN+zCr8LuV6bPFdq50304114vJYJ8RDyK8D5O9Phpbd6SZWgI7PwzmmfN1upeOJlvybDSgCw==
 
-object-assign@^4.1.1:
+object-assign@^4.0.1, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
@@ -4497,6 +4722,11 @@ path-to-regexp@^6.2.0:
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-6.2.1.tgz#d54934d6798eb9e5ef14e7af7962c945906918e5"
   integrity sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==
 
+path-type@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
+  integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
+
 picocolors@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
@@ -4507,7 +4737,7 @@ picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3, picomatch@^2.3.1:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
-pirates@^4.0.4:
+pirates@^4.0.1, pirates@^4.0.4:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.5.tgz#feec352ea5c3268fb23a37c702ab1699f35a5f3b"
   integrity sha512-8V9+HQPupnaXMA23c5hvl69zXvTwTzyAYasnkb0Tts4XvO4CliqONMOnvlq26rkhLC3nWDFBJf73LU1e1VZLaQ==
@@ -4528,6 +4758,14 @@ posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
   integrity sha512-xTgYBc3fuo7Yt7JbiuFxSYGToMoz8fLoE6TC9Wx1P/u+LfeThMOAqmuyECnlBaaJb+u1m9hHiXUEtwW4OzfUJg==
+
+postcss-load-config@^3.0.1:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/postcss-load-config/-/postcss-load-config-3.1.4.tgz#1ab2571faf84bb078877e1d07905eabe9ebda855"
+  integrity sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==
+  dependencies:
+    lilconfig "^2.0.5"
+    yaml "^1.10.2"
 
 prelude-ls@^1.2.1:
   version "1.2.1"
@@ -4864,6 +5102,13 @@ rimraf@^3.0.0, rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
+rollup@^3.2.5:
+  version "3.20.4"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-3.20.4.tgz#cde35731c5c0c637de0b532d5d1a84bd802c128e"
+  integrity sha512-n7J4tuctZXUErM9Uc916httwqmTc63zzCr2+TLCiSCpfO/Xuk3g/marGN1IlRJZi+QF3XMYx75PxXRfZDVgaRw==
+  optionalDependencies:
+    fsevents "~2.3.2"
+
 rpc-websockets@^7.5.1:
   version "7.5.1"
   resolved "https://registry.yarnpkg.com/rpc-websockets/-/rpc-websockets-7.5.1.tgz#e0a05d525a97e7efc31a0617f093a13a2e10c401"
@@ -5086,6 +5331,13 @@ source-map-url@^0.4.0:
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.1.tgz#0af66605a745a5a2f91cf1bbf8a7afbc283dec56"
   integrity sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==
 
+source-map@0.8.0-beta.0:
+  version "0.8.0-beta.0"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.8.0-beta.0.tgz#d4c1bb42c3f7ee925f005927ba10709e0d1d1f11"
+  integrity sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==
+  dependencies:
+    whatwg-url "^7.0.0"
+
 source-map@^0.5.6:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
@@ -5224,6 +5476,19 @@ strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
+sucrase@^3.20.3:
+  version "3.32.0"
+  resolved "https://registry.yarnpkg.com/sucrase/-/sucrase-3.32.0.tgz#c4a95e0f1e18b6847127258a75cf360bc568d4a7"
+  integrity sha512-ydQOU34rpSyj2TGyz4D2p8rbktIOZ8QY9s+DGLvFU1i5pWJE8vkpruCjGCMHsdXwnD7JDcS+noSwM/a7zyNFDQ==
+  dependencies:
+    "@jridgewell/gen-mapping" "^0.3.2"
+    commander "^4.0.0"
+    glob "7.1.6"
+    lines-and-columns "^1.1.6"
+    mz "^2.7.0"
+    pirates "^4.0.1"
+    ts-interface-checker "^0.1.9"
+
 superstruct@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/superstruct/-/superstruct-1.0.3.tgz#de626a5b49c6641ff4d37da3c7598e7a87697046"
@@ -5290,6 +5555,20 @@ text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==
 
+thenify-all@^1.0.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/thenify-all/-/thenify-all-1.6.0.tgz#1a1918d402d8fc3f98fbf234db0bcc8cc10e9726"
+  integrity sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==
+  dependencies:
+    thenify ">= 3.1.0 < 4"
+
+"thenify@>= 3.1.0 < 4":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/thenify/-/thenify-3.3.1.tgz#8932e686a4066038a016dd9e2ca46add9838a95f"
+  integrity sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==
+  dependencies:
+    any-promise "^1.0.0"
+
 "through@>=2.2.7 <3", through@^2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
@@ -5354,6 +5633,13 @@ tough-cookie@^4.0.0:
     universalify "^0.2.0"
     url-parse "^1.5.3"
 
+tr46@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-1.0.1.tgz#a8b13fd6bfd2489519674ccde55ba3693b706d09"
+  integrity sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==
+  dependencies:
+    punycode "^2.1.0"
+
 tr46@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-3.0.0.tgz#555c4e297a950617e8eeddef633c87d4d9d6cbf9"
@@ -5366,10 +5652,40 @@ tr46@~0.0.3:
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
   integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
 
+tree-kill@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
+  integrity sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==
+
+ts-interface-checker@^0.1.9:
+  version "0.1.13"
+  resolved "https://registry.yarnpkg.com/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz#784fd3d679722bc103b1b4b8030bcddb5db2a699"
+  integrity sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==
+
 tslib@^2.1.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.0.tgz#42bfed86f5787aeb41d031866c8f402429e0fddf"
   integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==
+
+tsup@^6.7.0:
+  version "6.7.0"
+  resolved "https://registry.yarnpkg.com/tsup/-/tsup-6.7.0.tgz#416f350f32a07b6ae86792ad7e52b0cafc566d64"
+  integrity sha512-L3o8hGkaHnu5TdJns+mCqFsDBo83bJ44rlK7e6VdanIvpea4ArPcU3swWGsLVbXak1PqQx/V+SSmFPujBK+zEQ==
+  dependencies:
+    bundle-require "^4.0.0"
+    cac "^6.7.12"
+    chokidar "^3.5.1"
+    debug "^4.3.1"
+    esbuild "^0.17.6"
+    execa "^5.0.0"
+    globby "^11.0.3"
+    joycon "^3.0.1"
+    postcss-load-config "^3.0.1"
+    resolve-from "^5.0.0"
+    rollup "^3.2.5"
+    source-map "0.8.0-beta.0"
+    sucrase "^3.20.3"
+    tree-kill "^1.2.2"
 
 tweetnacl@^1.0.3:
   version "1.0.3"
@@ -5573,6 +5889,11 @@ webidl-conversions@^3.0.0:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
   integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
 
+webidl-conversions@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
+  integrity sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
+
 webidl-conversions@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-7.0.0.tgz#256b4e1882be7debbf01d05f0aa2039778ea080a"
@@ -5613,6 +5934,15 @@ whatwg-url@^5.0.0:
   dependencies:
     tr46 "~0.0.3"
     webidl-conversions "^3.0.0"
+
+whatwg-url@^7.0.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-7.1.0.tgz#c2c492f1eca612988efd3d2266be1b9fc6170d06"
+  integrity sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==
+  dependencies:
+    lodash.sortby "^4.7.0"
+    tr46 "^1.0.1"
+    webidl-conversions "^4.0.2"
 
 which-module@^2.0.0:
   version "2.0.0"
@@ -5720,6 +6050,11 @@ yallist@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
+
+yaml@^1.10.2:
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
+  integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
 yargs-parser@^18.1.2:
   version "18.1.3"


### PR DESCRIPTION
[tsup website](https://github.com/egoist/tsup)

This is ts bundling easy-mode. Look at the `package.json` scripts for how you would run it. It _bundles_ the ts. This solves the awkward imports problem. I went ahead and included the `tsup/` out-dir for demo purposes, so you can see what it outputs based on the script flags. Normally this would be in `dist/` and `.gitignore`'d.

This is the end of my timeboxed research. If one was to be brazen we could just switch over to it ASAP. As a person unfamiliar with this codebase, if I had more time here is what I would do:

1. Deeply read through the scripts to see if they are doing anything important that would be overlooked in the move to `tsup`. The transition to a build/bundler would imply deleting the `scripts/` folder, so I'd want to understand what each script is doing so we don't forget to include something. For example, there are prod and dev versions that on first pass reading had identical outputs. But, a dev version _could_ exist with source-maps (available in `tsup` by the way).
2. Figure out a way to test drive the dist dir. There's clearly some sort of testing already in a few places, python, `test.sh`, and jest. Figuring out what's going on there and adding a test that fails to import the two types I wanted to from `ethos-connect`, and then passing it by moving to tsup. That would give me confidence in my changeset. But, this is open-ended. I'm not sure how I would do this yet.

Future tasks are:
1. Automating the deploy pipeline. You can setup github actions to deploy to npm.
2. Automate changelogs as part of the auto-deploy pipeline. I'm currently exploring solutions in this space, so no recommendations. I've heard good things about [changesets](https://github.com/changesets/changesets) and I'm currently researching it for a few personal projects that deploy to npm (I currently have a manual local deploy because they are solo projects).