### PR TITLE
Switch to `lodash-es` to reduce bundle size

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@testing-library/react": "^13.0.0",
     "@testing-library/react-hooks": "^8.0.1",
     "@types/jest": "^28.1.0",
-    "@types/lodash": "^4.14.191",
+    "@types/lodash-es": "^4.17.7",
     "@types/qrcode": "^1.4.2",
     "@types/react": "^18.0.28",
     "@types/react-dom": "^18.0.11",
@@ -78,7 +78,7 @@
     "cross-fetch": "^3.1.5",
     "encoding": "^0.1.13",
     "eslint": "^8.36.0",
-    "lodash": "^4.17.21",
+    "lodash-es": "^4.17.21",
     "qrcode": "^1.5.1",
     "react-google-recaptcha": "^2.1.0",
     "store2": "^2.14.2"

--- a/src/lib/getBagNFT.ts
+++ b/src/lib/getBagNFT.ts
@@ -1,5 +1,6 @@
 import { getObjectFields, is, SuiObjectData } from '@mysten/sui.js';
-import _ from 'lodash';
+import has from 'lodash-es/has';
+import get from 'lodash-es/get';
 import { ipfsConversion } from '../lib/getWalletContents';
 
 import type {
@@ -181,14 +182,14 @@ export const isBagNFT = (data: SuiObjectData): boolean => {
 const getBagNFT = async (provider: JsonRpcProvider, data: SuiObjectData) => {
     if (
         !isBagNFT(data) ||
-        !_.has(data, ID_PATH) ||
-        !_.has(data, BAG_ID_PATH) ||
-        !_.has(data, LOGICAL_OWNER_PATH)
+        !has(data, ID_PATH) ||
+        !has(data, BAG_ID_PATH) ||
+        !has(data, LOGICAL_OWNER_PATH)
     ) return data;    
 
-    const id = _.get(data, ID_PATH);
-    const bagId = _.get(data, BAG_ID_PATH);
-    const owner = _.get(data, LOGICAL_OWNER_PATH);
+    const id = get(data, ID_PATH);
+    const bagId = get(data, BAG_ID_PATH);
+    const owner = get(data, LOGICAL_OWNER_PATH);
     const bagObjects = await provider.getDynamicFields({ parentId: bagId || "" });
     const objectIds = bagObjects.data.map((bagObject) => bagObject.objectId);
     const objects = await provider.multiGetObjects({

--- a/src/lib/getKioskNFT.ts
+++ b/src/lib/getKioskNFT.ts
@@ -1,6 +1,6 @@
 import { JsonRpcProvider, SuiObjectData, SuiObjectResponse } from "@mysten/sui.js";
 import { DynamicFieldInfo } from "@mysten/sui.js/dist/types/dynamic_fields";
-import _ from 'lodash';
+import get from 'lodash-es/get';
 
 export const isKiosk = (data: SuiObjectData): boolean => {
     return (
@@ -17,7 +17,7 @@ export const getKioskObjects = async (
     data: SuiObjectData
 ): Promise<SuiObjectResponse[]> => {
     if (!isKiosk(data)) return [];
-        const kiosk = _.get(data, 'content.fields.kiosk');
+        const kiosk = get(data, 'content.fields.kiosk');
         if (!kiosk) return [];
         let allKioskObjects: DynamicFieldInfo[] = [];
         let cursor: string | undefined | null;

--- a/src/lib/nameService.ts
+++ b/src/lib/nameService.ts
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import get from 'lodash-es/get';
 import { Connection, JsonRpcProvider, TransactionBlock } from '@mysten/sui.js';
 import { DEFAULT_NETWORK } from './constants';
 
@@ -33,7 +33,7 @@ export const getSuiName = async (address: string, network: string, sender: strin
         ],
       })
     )
-    const resolverBytes = _.get(
+    const resolverBytes = get(
       await suiProvider.devInspectTransactionBlock({
         transactionBlock: registryTx,
         sender
@@ -58,7 +58,7 @@ export const getSuiName = async (address: string, network: string, sender: strin
       sender
     })
   
-    const nameByteArray = _.get(resolverResponse, DEV_INSPECT_RESULT_PATH_0);
+    const nameByteArray = get(resolverResponse, DEV_INSPECT_RESULT_PATH_0);
     if (!nameByteArray) return address;
 
     const name = toString(nameByteArray);
@@ -89,7 +89,7 @@ export const getSuiAddress = async (domain: string, network: string, sender: str
       sender
     });
 
-    const resolverBytes = _.get(resolverResponse, DEV_INSPECT_RESULT_PATH_1);
+    const resolverBytes = get(resolverResponse, DEV_INSPECT_RESULT_PATH_1);
     if (!resolverBytes) return domain;
 
     const resolver = toFullAddress(toHexString(resolverBytes));
@@ -107,7 +107,7 @@ export const getSuiAddress = async (domain: string, network: string, sender: str
       transactionBlock: resolverTx,
       sender, 
     })
-    const addr = _.get(resolverResponse2, DEV_INSPECT_RESULT_PATH_0)
+    const addr = get(resolverResponse2, DEV_INSPECT_RESULT_PATH_0)
 
     if (!addr) return domain;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1131,10 +1131,17 @@
     "@types/parse5" "^6.0.3"
     "@types/tough-cookie" "*"
 
-"@types/lodash@^4.14.191":
-  version "4.14.191"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.191.tgz#09511e7f7cba275acd8b419ddac8da9a6a79e2fa"
-  integrity sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ==
+"@types/lodash-es@^4.17.7":
+  version "4.17.7"
+  resolved "https://registry.yarnpkg.com/@types/lodash-es/-/lodash-es-4.17.7.tgz#22edcae9f44aff08546e71db8925f05b33c7cc40"
+  integrity sha512-z0ptr6UI10VlU6l5MYhGwS4mC8DZyYer2mCoyysZtSF7p26zOX8UpbrV0YpNYLGS8K4PUFIyEr62IMFFjveSiQ==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
+  version "4.14.194"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.194.tgz#b71eb6f7a0ff11bff59fc987134a093029258a76"
+  integrity sha512-r22s9tAS7imvBt2lyHC9B8AGwWnXaYb1tY09oyLkXDs4vArpYJzw09nj8MLx5VfciBPGIb+ZwG0ssYnEPJxn/g==
 
 "@types/node@*":
   version "18.11.0"
@@ -3686,12 +3693,17 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
+lodash-es@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
+  integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
+
 lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
-lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.21:
+lodash@^4.17.14, lodash@^4.17.15:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
The build tool cannot statically analyse `import * from 'lodash'`, switching to esm format helps reduce the bundle size.