### PR TITLE
add: dripSuiV2, deprecate V1

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,7 @@ import hideWallet from './lib/hideWallet';
 import showWallet from './lib/showWallet';
 
 import { formatBalance } from './lib/bigNumber';
-import dripSui from './lib/dripSui';
+import dripSui, { dripSuiV2 } from './lib/dripSui';
 import { getSuiAddress, getSuiName } from './lib/nameService';
 import truncateMiddle from './lib/truncateMiddle';
 
@@ -86,6 +86,7 @@ const ethos = {
   checkForAssetType,
 
   dripSui,
+  dripSuiV2,
   getSuiName,
   getSuiAddress,
   formatBalance,

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,7 @@ import hideWallet from './lib/hideWallet';
 import showWallet from './lib/showWallet';
 
 import { formatBalance } from './lib/bigNumber';
-import dripSui, { dripSuiV2 } from './lib/dripSui';
+import dripSui from './lib/dripSui';
 import { getSuiAddress, getSuiName } from './lib/nameService';
 import truncateMiddle from './lib/truncateMiddle';
 
@@ -86,7 +86,6 @@ const ethos = {
   checkForAssetType,
 
   dripSui,
-  dripSuiV2,
   getSuiName,
   getSuiAddress,
   formatBalance,

--- a/src/lib/dripSui.ts
+++ b/src/lib/dripSui.ts
@@ -1,28 +1,11 @@
-import { Connection, JsonRpcProvider } from '@mysten/sui.js';
-import { DEFAULT_NETWORK, DEFAULT_FAUCET } from './constants';
-import {requestSuiFromFaucetV0, getFaucetHost} from '@mysten/sui.js/faucet'
+import { getFaucetHost, requestSuiFromFaucetV0 } from '@mysten/sui.js/faucet';
 
-type DripSuiProps = {
-  address: string,
-  network?: string
-  faucet?: string
-}
-
-/**
- * @deprecated please use `dripSuiV2` instead
- */
-const dripSui = async ({ address, network, faucet }: DripSuiProps) => {
-  const connection = new Connection({ fullnode: network ?? DEFAULT_NETWORK, faucet: `${faucet ?? DEFAULT_FAUCET}gas` })
-  const provider = new JsonRpcProvider(connection);
-  return provider.requestSuiFromFaucet(address)
-}
-
-type DripSuiV2Params = {
+type DripSuiParams = {
   address: string
   networkName: Parameters<typeof getFaucetHost>[0]
 }
 
-export const dripSuiV2 = async ({ address, networkName }: DripSuiV2Params) => {
+const dripSui = async ({ address, networkName }: DripSuiParams) => {
   return requestSuiFromFaucetV0({
     host: getFaucetHost(networkName),
     recipient: address

--- a/src/lib/dripSui.ts
+++ b/src/lib/dripSui.ts
@@ -1,5 +1,6 @@
 import { Connection, JsonRpcProvider } from '@mysten/sui.js';
 import { DEFAULT_NETWORK, DEFAULT_FAUCET } from './constants';
+import {requestSuiFromFaucetV0, getFaucetHost} from '@mysten/sui.js/faucet'
 
 type DripSuiProps = {
   address: string,
@@ -7,10 +8,25 @@ type DripSuiProps = {
   faucet?: string
 }
 
+/**
+ * @deprecated please use `dripSuiV2` instead
+ */
 const dripSui = async ({ address, network, faucet }: DripSuiProps) => {
   const connection = new Connection({ fullnode: network ?? DEFAULT_NETWORK, faucet: `${faucet ?? DEFAULT_FAUCET}gas` })
   const provider = new JsonRpcProvider(connection);
   return provider.requestSuiFromFaucet(address)
+}
+
+type DripSuiV2Params = {
+  address: string
+  networkName: Parameters<typeof getFaucetHost>[0]
+}
+
+export const dripSuiV2 = async ({ address, networkName }: DripSuiV2Params) => {
+  return requestSuiFromFaucetV0({
+    host: getFaucetHost(networkName),
+    recipient: address
+  })
 }
 
 export default dripSui


### PR DESCRIPTION
This is an idea for how to handle the faucet changes.

## Alternatives

These alternatives are also easily implemented, so really it's pick-your-favorite @jaredcosulich. I preferred mine because the alternatives below ended up ignoring parameters. My "deprecation" strategy is streamlined, with the major drawback of introducing a v2 function and a deprecation.

### Inference

We could, internal to `dripSui` (so, v1), write a function that infers the network-name based on the input network. E.g.,

```ts
infer("https://fullnode.testnet.sui.io/") => "testnet"
```

Then we don't intro V2, and handle it internal to `dripSui`

### Trust

We can trust that the faucet URL is correct as supplied, and so instead of using `getFaucetHost`, we just use the `faucet` value supplied from the input to `dripSui`.